### PR TITLE
Align Accelerometer interface with the Generic Sensor API

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -10,7 +10,7 @@ Editor: Alexander Shalamov 78335, Intel Corporation, https://intel.com/
 Group: dap
 Abstract:
   This specification defines accelerometer sensor interface for
-  obtaining information about acceleration applied to the X, Y and Z axis
+  obtaining information about <a>acceleration</a> applied to the X, Y and Z axis
   of a device that hosts the sensor.
 Version History: https://github.com/w3c/accelerometer/commits/gh-pages/index.bs
 !Bug Reports: <a href="https://www.github.com/w3c/accelerometer/issues/new">via the w3c/accelerometer repository on GitHub</a>
@@ -24,18 +24,12 @@ Default Biblio Status: current
 Note class: note
 </pre>
 <pre class="anchors">
-urlPrefix: https://w3c.github.io/permissions/; spec: PERMISSIONS
-  type: dfn
-    text: permission; url: idl-def-Permission
-    text: associated PermissionDescriptor;  url: dfn-associated-permissiondescriptor
 urlPrefix: https://w3c.github.io/sensors; spec: GENERIC-SENSOR
   type: dfn
     text: high-level
-    text: sensor subclass
-    text: sensorreading subclass
+    text: sensor
+    text: latest reading
     text: default sensor
-    text: supported reporting mode; url: supported-reporting-modes
-    text: auto
     text: construct a sensor object; url: construct-sensor-object
 </pre>
 
@@ -43,7 +37,7 @@ Introduction {#intro}
 ============
 
 The Accelerometer API extends the Generic Sensor API [[GENERIC-SENSOR]]
-interface to provide information about acceleration applied to device's
+interface to provide information about <a>acceleration</a> applied to device's
 X, Y and Z axis in <a>local coordinate system</a> defined by device.
 
 Examples {#examples}
@@ -51,13 +45,13 @@ Examples {#examples}
 
 <div class="example">
     <pre highlight="js">
-    let sensor = new Accelerometer({includeGravity: false, frequency: 60});
+    let sensor = new Accelerometer();
     sensor.start();
 
-    sensor.onchange = event => {
-        console.log("Linear acceleration for an X-axis: " + event.reading.x);
-        console.log("Linear acceleration for an Y-axis: " + event.reading.y);
-        console.log("Linear acceleration for an Z-axis: " + event.reading.z);
+    sensor.onchange = () => {
+        console.log("Acceleration along X-axis: " + sensor.x);
+        console.log("Acceleration along Y-axis: " + sensor.y);
+        console.log("Acceleration along Z-axis: " + sensor.z);
     }
 
     sensor.onerror = event => console.log(event.error.name, event.error.message);
@@ -73,50 +67,30 @@ beyond those described in the Generic Sensor API [[!GENERIC-SENSOR]].
 Model {#model}
 =====
 
-The Accelerometer's associated <a>Sensor subclass</a>
-is the {{Accelerometer}} class.
+The accelerometer's associated {{Sensor}} subclass is the {{Accelerometer}} class.
 
-The Accelerometer's associated <a>SensorReading subclass</a>
-is the {{AccelerometerReading}} class.
+Accelerometer has a <a>default sensor</a>, which is the device's main accelerometer sensor.
 
-The Accelerometer has a <a>default sensor</a>,
-which is the device's main accelerometer sensor.
+A [=latest reading=] per [=sensor=] of accelerometer type includes three [=map/entries=]
+whose [=map/keys=] are "x", "y", "z" and whose [=map/values=] contain device's <a>acceleration</a>
+about the corresponding axes.
 
-The Accelerometer has a single <a>supported reporting mode</a>
-which is "<a>periodic</a>".
+The <dfn>acceleration</dfn> is the rate of change of velocity of a device with respect to time. Its 
+unit is the metre per second squared (m/s^2) [[SI]].
 
-The Accelerometer's <a>permission</a> name is "accelerometer".
-It has no <a>associated PermissionDescriptor</a>.
+The frame of reference for the <a>acceleration</a> measurement must be inertial, such as, the device in free fall would
+provide 0 (m/s^2) <a>acceleration</a> value for each axis.
 
-The Accelerometer has an associated abstract operation
-to <dfn>retrieve the sensor permission</dfn> which
-must simply return a <a>permission</a> whose name is "accelerometer".
-
-The Accelerometer has an associated abstract operation
-to <dfn lt="Construct SensorReading Object">construct a SensorReading object</dfn>
-which creates a new {{AccelerometerReading}} object and sets its
-<a attribute for="AccelerometerReading">x</a>,
-<a attribute for="AccelerometerReading">y</a> and
-<a attribute for="AccelerometerReading">z</a> attributes
-to zero.
-
-The <dfn>linear acceleration</dfn> is an acceleration that is applied to the device that hosts
-the sensor, without the contribution of a gravity force.
-
-The {{AccelerometerReading}}'s attribute values must be in [[SI]] units for acceleration, metre
-per second squared (m/s^2), expressed in a three-dimentional Cartesian <a>local coordinate system</a>
-defined by the device.
-
-The frame of reference for the acceleration measurement must be inertial, such as device in free fall would
-provide 0 (m/s^2) acceleration value for each axis.
-
-The sign of the acceleration values must be according to the right-hand convention in a <a>local coordinate
+The sign of the <a>acceleration</a> values must be according to the right-hand convention in a <a>local coordinate
 system</a> defined by the device.
 
 Note: The <dfn>local coordinate system</dfn> of a mobile device is usually defined relative to
 the device's screen when the device in its default orientation (see figure below).
 
 <img src="accelerometer_coordinate_system.png" srcset="accelerometer_coordinate_system.svg" alt="Accelerometer coordinate system.">
+
+The <dfn>linear acceleration</dfn> is an <a>acceleration</a> that is applied to the device that hosts
+the sensor, without the contribution of a gravity force.
 
 API {#api}
 ===
@@ -127,13 +101,40 @@ The Accelerometer Interface {#accelerometer-interface}
 <pre class="idl">
   [Constructor(optional AccelerometerOptions accelerometerOptions)]
   interface Accelerometer : Sensor {
-    readonly attribute AccelerometerReading? reading;
+    readonly attribute unrestricted double? x;
+    readonly attribute unrestricted double? y;
+    readonly attribute unrestricted double? z;
     readonly attribute boolean includesGravity;
   };
 </pre>
 
 To <dfn>Construct an Accelerometer Object</dfn> the user agent must invoke
 the <a>construct a Sensor object</a> abstract operation.
+
+### Accelerometer.x ### {#accelerometer-x}
+
+The {{Accelerometer/x!!attribute}} attribute of the {{Accelerometer}}
+interface represents the <a>acceleration</a> along X-axis.
+This attribute returns [=map/value=] for [=latest reading=]["x"] [=map/entry=].
+
+### Accelerometer.y ### {#accelerometer-y}
+
+The {{Accelerometer/y!!attribute}} attribute of the {{Accelerometer}}
+interface represents the <a>acceleration</a> along Y-axis.
+This attribute returns [=map/value=] for [=latest reading=]["y"] [=map/entry=].
+
+### Accelerometer.z ### {#accelerometer-z}
+
+The {{Accelerometer/z!!attribute}} attribute of the {{Accelerometer}}
+interface represents the <a>acceleration</a> along Z-axis.
+This attribute returns [=map/value=] for [=latest reading=]["z"] [=map/entry=].
+
+### Accelerometer.includesGravity ### {#accelerometer-includesGravity}
+
+The {{Accelerometer/includesGravity!!attribute}} attribute of the {{Accelerometer}}
+interface represents whether the <a>acceleration</a> information provided by the sensor includes the effect of the gravity
+force. In case when {{Accelerometer/includesGravity!!attribute}} equals to false, {{Accelerometer}}
+will provide <a>linear acceleration</a> information.
 
 The AccelerometerOptions Dictionary {#accelerometer-options-dictionary}
 --------------------------------
@@ -144,52 +145,9 @@ The AccelerometerOptions Dictionary {#accelerometer-options-dictionary}
   };
 </pre>
 
-By default, Accelerometer would provide acceleration information including
-the effect of the gravity force. In cases, when <a>linear acceleration</a> information is
-required, {{AccelerometerOptions}} dictionary with and dictionary member
-<a attribute for="AccelerometerOptions">includeGravity</a> that is set to false,
-must be provided to {{Accelerometer}} constructor.
-
-The AccelerometerReading Interface {#accelerometer-reading-interface}
----------------------------------------
-
-<pre class="idl">
-  [Constructor(AccelerometerReadingInit AccelerometerReadingInit)]
-  interface AccelerometerReading : SensorReading {
-      readonly attribute double x;
-      readonly attribute double y;
-      readonly attribute double z;
-  };
-
-  dictionary AccelerometerReadingInit {
-      double x = 0;
-      double y = 0;
-      double z = 0;
-  };
-</pre>
-
-### The Accelerometer attributes ### {#accelerometer-attributes}
-
-The <a attribute for="Accelerometer">includesGravity</a> attribute of the {{Accelerometer}}
-interface represents whether the acceleration information provided by the sensor includes effect of the gravity
-force. In case when <a attribute for="Accelerometer">includesGravity</a> equals to false, {{Accelerometer}}
-will provide <a>linear acceleration</a> information.
-
-### The AccelerometerReading constructor ### {#accelerometer-reading-constructor}
-
-The AccelerometerReading constructor accepts {{AccelerometerReadingInit}} dictionary that is used
-for initialization of {{AccelerometerReading}} attributes.
-
-### The AccelerometerReading attributes ### {#accelerometer-reading-attributes}
-
-The <a attribute for="AccelerometerReading">x</a> attribute of the {{AccelerometerReading}}
-interface represents the <a>acceleration</a> along X-axis.
-
-The <a attribute for="AccelerometerReading">y</a> attribute of the {{AccelerometerReading}}
-interface represents the <a>acceleration</a> along Y-axis.
-
-The <a attribute for="AccelerometerReading">z</a> attribute of the {{AccelerometerReading}}
-interface represents the <a>acceleration</a> along Z-axis.
+By default, accelerometer sensor provides <a>acceleration</a> information including the effect of the gravity force.
+In cases when <a>linear acceleration</a> information is required, {{AccelerometerOptions}} dictionary
+must include an [=map/entry=] whose [=map/key=] is "includeGravity" and whose [=map/value=] is false.
 
 Acknowledgements {#acknowledgements}
 ================

--- a/index.html
+++ b/index.html
@@ -415,6 +415,19 @@
 	 border-left: 0.5em solid #DEF;
 	}
 
+	/* Put nice boxes around each algorithm. */
+	[data-algorithm]:not(.heading) {
+	  padding: .5em;
+	  border: thin solid #ddd; border-radius: .5em;
+	  margin: .5em 0;
+	}
+	[data-algorithm]:not(.heading) > :first-child {
+	  margin-top: 0;
+	}
+	[data-algorithm]:not(.heading) > :last-child {
+	  margin-bottom: 0;
+	}
+
 	/* Style for switch/case <dl>s */
 	dl.switch > dd > ol.only,
 	dl.switch > dd > .only > ol {
@@ -1415,7 +1428,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Accelerometer</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-10-28">28 October 2016</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-02-02">2 February 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1438,14 +1451,14 @@ pre.idl.highlight { color: #708090; }
     </dl>
    </div>
    <div data-fill-with="warning"></div>
-   <p class="copyright" data-fill-with="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2016 <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="http://www.w3.org/Consortium/Legal/2015/copyright-software-and-document">permissive document license</a> rules apply. </p>
+   <p class="copyright" data-fill-with="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2017 <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="http://www.w3.org/Consortium/Legal/2015/copyright-software-and-document">permissive document license</a> rules apply. </p>
    <hr title="Separator for header">
   </div>
   <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>
   <div class="p-summary" data-fill-with="abstract">
    <p>This specification defines accelerometer sensor interface for
 
-obtaining information about acceleration applied to the X, Y and Z axis
+obtaining information about <a data-link-type="dfn" href="#acceleration">acceleration</a> applied to the X, Y and Z axis
 of a device that hosts the sensor.</p>
   </div>
   <h2 class="no-num no-toc no-ref heading settled" id="sotd"><span class="content">Status of this document</span></h2>
@@ -1480,15 +1493,15 @@ of a device that hosts the sensor.</p>
     <li>
      <a href="#api"><span class="secno">5</span> <span class="content">API</span></a>
      <ol class="toc">
-      <li><a href="#accelerometer-interface"><span class="secno">5.1</span> <span class="content">The Accelerometer Interface</span></a>
-      <li><a href="#accelerometer-options-dictionary"><span class="secno">5.2</span> <span class="content">The AccelerometerOptions Dictionary</span></a>
       <li>
-       <a href="#accelerometer-reading-interface"><span class="secno">5.3</span> <span class="content">The AccelerometerReading Interface</span></a>
+       <a href="#accelerometer-interface"><span class="secno">5.1</span> <span class="content">The Accelerometer Interface</span></a>
        <ol class="toc">
-        <li><a href="#accelerometer-attributes"><span class="secno">5.3.1</span> <span class="content">The Accelerometer attributes</span></a>
-        <li><a href="#accelerometer-reading-constructor"><span class="secno">5.3.2</span> <span class="content">The AccelerometerReading constructor</span></a>
-        <li><a href="#accelerometer-reading-attributes"><span class="secno">5.3.3</span> <span class="content">The AccelerometerReading attributes</span></a>
+        <li><a href="#accelerometer-x"><span class="secno">5.1.1</span> <span class="content">Accelerometer.x</span></a>
+        <li><a href="#accelerometer-y"><span class="secno">5.1.2</span> <span class="content">Accelerometer.y</span></a>
+        <li><a href="#accelerometer-z"><span class="secno">5.1.3</span> <span class="content">Accelerometer.z</span></a>
+        <li><a href="#accelerometer-includesGravity"><span class="secno">5.1.4</span> <span class="content">Accelerometer.includesGravity</span></a>
        </ol>
+      <li><a href="#accelerometer-options-dictionary"><span class="secno">5.2</span> <span class="content">The AccelerometerOptions Dictionary</span></a>
      </ol>
     <li><a href="#acknowledgements"><span class="secno">6</span> <span class="content">Acknowledgements</span></a>
     <li><a href="#conformance"><span class="secno">7</span> <span class="content">Conformance</span></a>
@@ -1509,94 +1522,73 @@ of a device that hosts the sensor.</p>
   </nav>
   <main>
    <h2 class="heading settled" data-level="1" id="intro"><span class="secno">1. </span><span class="content">Introduction</span><a class="self-link" href="#intro"></a></h2>
-   <p>The Accelerometer API extends the Generic Sensor API <a data-link-type="biblio" href="#biblio-generic-sensor">[GENERIC-SENSOR]</a> interface to provide information about acceleration applied to device’s
+   <p>The Accelerometer API extends the Generic Sensor API <a data-link-type="biblio" href="#biblio-generic-sensor">[GENERIC-SENSOR]</a> interface to provide information about <a data-link-type="dfn" href="#acceleration" id="ref-for-acceleration-1">acceleration</a> applied to device’s
 X, Y and Z axis in <a data-link-type="dfn" href="#local-coordinate-system" id="ref-for-local-coordinate-system-1">local coordinate system</a> defined by device.</p>
    <h2 class="heading settled" data-level="2" id="examples"><span class="secno">2. </span><span class="content">Examples</span><a class="self-link" href="#examples"></a></h2>
-   <div class="example" id="example-13fdcb2f">
-    <a class="self-link" href="#example-13fdcb2f"></a> 
-<pre class="highlight"><span></span><span class="kd">let</span> <span class="nx">sensor</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">Accelerometer</span><span class="p">({</span><span class="nx">includeGravity</span><span class="o">:</span> <span class="kc">false</span><span class="p">,</span> <span class="nx">frequency</span><span class="o">:</span> <span class="mi">60</span><span class="p">});</span>
-<span class="nx">sensor</span><span class="p">.</span><span class="nx">start</span><span class="p">();</span>
+   <div class="example" id="example-a773d78c">
+    <a class="self-link" href="#example-a773d78c"></a> 
+<pre class="highlight"><span class="kd">let</span> sensor <span class="o">=</span> <span class="k">new</span> Accelerometer<span class="p">(</span><span class="p">)</span><span class="p">;</span>
+sensor<span class="p">.</span>start<span class="p">(</span><span class="p">)</span><span class="p">;</span>
 
-<span class="nx">sensor</span><span class="p">.</span><span class="nx">onchange</span> <span class="o">=</span> <span class="nx">event</span> <span class="o">=></span> <span class="p">{</span>
-    <span class="nx">console</span><span class="p">.</span><span class="nx">log</span><span class="p">(</span><span class="s2">"Linear acceleration for an X-axis: "</span> <span class="o">+</span> <span class="nx">event</span><span class="p">.</span><span class="nx">reading</span><span class="p">.</span><span class="nx">x</span><span class="p">);</span>
-    <span class="nx">console</span><span class="p">.</span><span class="nx">log</span><span class="p">(</span><span class="s2">"Linear acceleration for an Y-axis: "</span> <span class="o">+</span> <span class="nx">event</span><span class="p">.</span><span class="nx">reading</span><span class="p">.</span><span class="nx">y</span><span class="p">);</span>
-    <span class="nx">console</span><span class="p">.</span><span class="nx">log</span><span class="p">(</span><span class="s2">"Linear acceleration for an Z-axis: "</span> <span class="o">+</span> <span class="nx">event</span><span class="p">.</span><span class="nx">reading</span><span class="p">.</span><span class="nx">z</span><span class="p">);</span>
+sensor<span class="p">.</span>onchange <span class="o">=</span> <span class="p">(</span><span class="p">)</span> <span class="o">=></span> <span class="p">{</span>
+    console<span class="p">.</span>log<span class="p">(</span><span class="s2">"Acceleration along X-axis: "</span> <span class="o">+</span> sensor<span class="p">.</span>x<span class="p">)</span><span class="p">;</span>
+    console<span class="p">.</span>log<span class="p">(</span><span class="s2">"Acceleration along Y-axis: "</span> <span class="o">+</span> sensor<span class="p">.</span>y<span class="p">)</span><span class="p">;</span>
+    console<span class="p">.</span>log<span class="p">(</span><span class="s2">"Acceleration along Z-axis: "</span> <span class="o">+</span> sensor<span class="p">.</span>z<span class="p">)</span><span class="p">;</span>
 <span class="p">}</span>
 
-<span class="nx">sensor</span><span class="p">.</span><span class="nx">onerror</span> <span class="o">=</span> <span class="nx">event</span> <span class="o">=></span> <span class="nx">console</span><span class="p">.</span><span class="nx">log</span><span class="p">(</span><span class="nx">event</span><span class="p">.</span><span class="nx">error</span><span class="p">.</span><span class="nx">name</span><span class="p">,</span> <span class="nx">event</span><span class="p">.</span><span class="nx">error</span><span class="p">.</span><span class="nx">message</span><span class="p">);</span>
+sensor<span class="p">.</span>onerror <span class="o">=</span> event <span class="o">=></span> console<span class="p">.</span>log<span class="p">(</span>event<span class="p">.</span>error<span class="p">.</span>name<span class="p">,</span> event<span class="p">.</span>error<span class="p">.</span>message<span class="p">)</span><span class="p">;</span>
 </pre>
    </div>
    <h2 class="heading settled" data-level="3" id="security-and-privacy"><span class="secno">3. </span><span class="content">Security and Privacy Considerations</span><a class="self-link" href="#security-and-privacy"></a></h2>
    <p>There are no specific security and privacy considerations
 beyond those described in the Generic Sensor API <a data-link-type="biblio" href="#biblio-generic-sensor">[GENERIC-SENSOR]</a>.</p>
    <h2 class="heading settled" data-level="4" id="model"><span class="secno">4. </span><span class="content">Model</span><a class="self-link" href="#model"></a></h2>
-   <p>The Accelerometer’s associated <a data-link-type="dfn" href="https://w3c.github.io/sensors#sensor-subclass">Sensor subclass</a> is the <code class="idl"><a data-link-type="idl" href="#accelerometer" id="ref-for-accelerometer-1">Accelerometer</a></code> class.</p>
-   <p>The Accelerometer’s associated <a data-link-type="dfn" href="https://w3c.github.io/sensors#sensorreading-subclass">SensorReading subclass</a> is the <code class="idl"><a data-link-type="idl" href="#accelerometerreading" id="ref-for-accelerometerreading-1">AccelerometerReading</a></code> class.</p>
-   <p>The Accelerometer has a <a data-link-type="dfn" href="https://w3c.github.io/sensors#default-sensor">default sensor</a>,
-which is the device’s main accelerometer sensor.</p>
-   <p>The Accelerometer has a single <a data-link-type="dfn" href="https://w3c.github.io/sensors#supported-reporting-modes">supported reporting mode</a> which is "<a data-link-type="dfn">periodic</a>".</p>
-   <p>The Accelerometer’s <a data-link-type="dfn" href="https://w3c.github.io/permissions/#idl-def-Permission">permission</a> name is "accelerometer".
-It has no <a data-link-type="dfn" href="https://w3c.github.io/permissions/#dfn-associated-permissiondescriptor">associated PermissionDescriptor</a>.</p>
-   <p>The Accelerometer has an associated abstract operation
-to <dfn data-dfn-type="dfn" data-noexport="" id="retrieve-the-sensor-permission">retrieve the sensor permission<a class="self-link" href="#retrieve-the-sensor-permission"></a></dfn> which
-must simply return a <a data-link-type="dfn" href="https://w3c.github.io/permissions/#idl-def-Permission">permission</a> whose name is "accelerometer".</p>
-   <p>The Accelerometer has an associated abstract operation
-to <dfn data-dfn-type="dfn" data-lt="Construct SensorReading Object" data-noexport="" id="construct-sensorreading-object">construct a SensorReading object<a class="self-link" href="#construct-sensorreading-object"></a></dfn> which creates a new <code class="idl"><a data-link-type="idl" href="#accelerometerreading" id="ref-for-accelerometerreading-2">AccelerometerReading</a></code> object and sets its <a class="idl-code" data-link-type="attribute" href="#dom-accelerometerreading-x" id="ref-for-dom-accelerometerreading-x-1">x</a>, <a class="idl-code" data-link-type="attribute" href="#dom-accelerometerreading-y" id="ref-for-dom-accelerometerreading-y-1">y</a> and <a class="idl-code" data-link-type="attribute" href="#dom-accelerometerreading-z" id="ref-for-dom-accelerometerreading-z-1">z</a> attributes
-to zero.</p>
-   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="linear-acceleration">linear acceleration</dfn> is an acceleration that is applied to the device that hosts
-the sensor, without the contribution of a gravity force.</p>
-   <p>The <code class="idl"><a data-link-type="idl" href="#accelerometerreading" id="ref-for-accelerometerreading-3">AccelerometerReading</a></code>'s attribute values must be in <a data-link-type="biblio" href="#biblio-si">[SI]</a> units for acceleration, metre
-per second squared (m/s^2), expressed in a three-dimentional Cartesian <a data-link-type="dfn" href="#local-coordinate-system" id="ref-for-local-coordinate-system-2">local coordinate system</a> defined by the device.</p>
-   <p>The frame of reference for the acceleration measurement must be inertial, such as device in free fall would
-provide 0 (m/s^2) acceleration value for each axis.</p>
-   <p>The sign of the acceleration values must be according to the right-hand convention in a <a data-link-type="dfn" href="#local-coordinate-system" id="ref-for-local-coordinate-system-3">local coordinate
+   <p>The accelerometer’s associated <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/sensors/#sensor">Sensor</a></code> subclass is the <code class="idl"><a data-link-type="idl" href="#accelerometer" id="ref-for-accelerometer-1">Accelerometer</a></code> class.</p>
+   <p>Accelerometer has a <a data-link-type="dfn" href="https://w3c.github.io/sensors#default-sensor">default sensor</a>, which is the device’s main accelerometer sensor.</p>
+   <p>A <a data-link-type="dfn" href="https://w3c.github.io/sensors#latest-reading">latest reading</a> per <a data-link-type="dfn" href="https://w3c.github.io/sensors#sensor">sensor</a> of accelerometer type includes three <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry">entries</a> whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-key">keys</a> are "x", "y", "z" and whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-value">values</a> contain device’s <a data-link-type="dfn" href="#acceleration" id="ref-for-acceleration-2">acceleration</a> about the corresponding axes.</p>
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="acceleration">acceleration</dfn> is the rate of change of velocity of a device with respect to time. Its
+unit is the metre per second squared (m/s^2) <a data-link-type="biblio" href="#biblio-si">[SI]</a>.</p>
+   <p>The frame of reference for the <a data-link-type="dfn" href="#acceleration" id="ref-for-acceleration-3">acceleration</a> measurement must be inertial, such as, the device in free fall would
+provide 0 (m/s^2) <a data-link-type="dfn" href="#acceleration" id="ref-for-acceleration-4">acceleration</a> value for each axis.</p>
+   <p>The sign of the <a data-link-type="dfn" href="#acceleration" id="ref-for-acceleration-5">acceleration</a> values must be according to the right-hand convention in a <a data-link-type="dfn" href="#local-coordinate-system" id="ref-for-local-coordinate-system-2">local coordinate
 system</a> defined by the device.</p>
    <p class="note" role="note">Note: The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="local-coordinate-system">local coordinate system</dfn> of a mobile device is usually defined relative to
 the device’s screen when the device in its default orientation (see figure below).</p>
    <p><img alt="Accelerometer coordinate system." src="accelerometer_coordinate_system.png" srcset="accelerometer_coordinate_system.svg"></p>
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="linear-acceleration">linear acceleration</dfn> is an <a data-link-type="dfn" href="#acceleration" id="ref-for-acceleration-6">acceleration</a> that is applied to the device that hosts
+the sensor, without the contribution of a gravity force.</p>
    <h2 class="heading settled" data-level="5" id="api"><span class="secno">5. </span><span class="content">API</span><a class="self-link" href="#api"></a></h2>
    <h3 class="heading settled" data-level="5.1" id="accelerometer-interface"><span class="secno">5.1. </span><span class="content">The Accelerometer Interface</span><a class="self-link" href="#accelerometer-interface"></a></h3>
 <pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="Accelerometer" data-dfn-type="constructor" data-export="" data-lt="Accelerometer(accelerometerOptions)|Accelerometer()" id="dom-accelerometer-accelerometer">Constructor<a class="self-link" href="#dom-accelerometer-accelerometer"></a></dfn>(<span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-accelerometeroptions" id="ref-for-dictdef-accelerometeroptions-1">AccelerometerOptions</a> <dfn class="nv idl-code" data-dfn-for="Accelerometer/Accelerometer(accelerometerOptions)" data-dfn-type="argument" data-export="" id="dom-accelerometer-accelerometer-accelerometeroptions-accelerometeroptions">accelerometerOptions<a class="self-link" href="#dom-accelerometer-accelerometer-accelerometeroptions-accelerometeroptions"></a></dfn>)]
 <span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="accelerometer">Accelerometer</dfn> : <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#sensor">Sensor</a> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#accelerometerreading" id="ref-for-accelerometerreading-4">AccelerometerReading</a>? <dfn class="nv idl-code" data-dfn-for="Accelerometer" data-dfn-type="attribute" data-export="" data-readonly="" data-type="AccelerometerReading?" id="dom-accelerometer-reading">reading<a class="self-link" href="#dom-accelerometer-reading"></a></dfn>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">unrestricted</span> <span class="kt">double</span>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="Accelerometer" data-dfn-type="attribute" data-export="" data-readonly="" data-type="unrestricted double?" id="dom-accelerometer-x">x</dfn>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">unrestricted</span> <span class="kt">double</span>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="Accelerometer" data-dfn-type="attribute" data-export="" data-readonly="" data-type="unrestricted double?" id="dom-accelerometer-y">y</dfn>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">unrestricted</span> <span class="kt">double</span>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="Accelerometer" data-dfn-type="attribute" data-export="" data-readonly="" data-type="unrestricted double?" id="dom-accelerometer-z">z</dfn>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">boolean</span> <dfn class="nv dfn-paneled idl-code" data-dfn-for="Accelerometer" data-dfn-type="attribute" data-export="" data-readonly="" data-type="boolean" id="dom-accelerometer-includesgravity">includesGravity</dfn>;
 };
 </pre>
    <p>To <dfn data-dfn-type="dfn" data-noexport="" id="construct-an-accelerometer-object">Construct an Accelerometer Object<a class="self-link" href="#construct-an-accelerometer-object"></a></dfn> the user agent must invoke
 the <a data-link-type="dfn" href="https://w3c.github.io/sensors#construct-sensor-object">construct a Sensor object</a> abstract operation.</p>
+   <h4 class="heading settled" data-level="5.1.1" id="accelerometer-x"><span class="secno">5.1.1. </span><span class="content">Accelerometer.x</span><a class="self-link" href="#accelerometer-x"></a></h4>
+   <p>The <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-accelerometer-x" id="ref-for-dom-accelerometer-x-1">x</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#accelerometer" id="ref-for-accelerometer-2">Accelerometer</a></code> interface represents the <a data-link-type="dfn" href="#acceleration" id="ref-for-acceleration-7">acceleration</a> along X-axis.
+This attribute returns <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-value">value</a> for <a data-link-type="dfn" href="https://w3c.github.io/sensors#latest-reading">latest reading</a>["x"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry">entry</a>.</p>
+   <h4 class="heading settled" data-level="5.1.2" id="accelerometer-y"><span class="secno">5.1.2. </span><span class="content">Accelerometer.y</span><a class="self-link" href="#accelerometer-y"></a></h4>
+   <p>The <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-accelerometer-y" id="ref-for-dom-accelerometer-y-1">y</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#accelerometer" id="ref-for-accelerometer-3">Accelerometer</a></code> interface represents the <a data-link-type="dfn" href="#acceleration" id="ref-for-acceleration-8">acceleration</a> along Y-axis.
+This attribute returns <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-value">value</a> for <a data-link-type="dfn" href="https://w3c.github.io/sensors#latest-reading">latest reading</a>["y"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry">entry</a>.</p>
+   <h4 class="heading settled" data-level="5.1.3" id="accelerometer-z"><span class="secno">5.1.3. </span><span class="content">Accelerometer.z</span><a class="self-link" href="#accelerometer-z"></a></h4>
+   <p>The <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-accelerometer-z" id="ref-for-dom-accelerometer-z-1">z</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#accelerometer" id="ref-for-accelerometer-4">Accelerometer</a></code> interface represents the <a data-link-type="dfn" href="#acceleration" id="ref-for-acceleration-9">acceleration</a> along Z-axis.
+This attribute returns <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-value">value</a> for <a data-link-type="dfn" href="https://w3c.github.io/sensors#latest-reading">latest reading</a>["z"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry">entry</a>.</p>
+   <h4 class="heading settled" data-level="5.1.4" id="accelerometer-includesGravity"><span class="secno">5.1.4. </span><span class="content">Accelerometer.includesGravity</span><a class="self-link" href="#accelerometer-includesGravity"></a></h4>
+   <p>The <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-accelerometer-includesgravity" id="ref-for-dom-accelerometer-includesgravity-1">includesGravity</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#accelerometer" id="ref-for-accelerometer-5">Accelerometer</a></code> interface represents whether the <a data-link-type="dfn" href="#acceleration" id="ref-for-acceleration-10">acceleration</a> information provided by the sensor includes the effect of the gravity
+force. In case when <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-accelerometer-includesgravity" id="ref-for-dom-accelerometer-includesgravity-2">includesGravity</a></code> equals to false, <code class="idl"><a data-link-type="idl" href="#accelerometer" id="ref-for-accelerometer-6">Accelerometer</a></code> will provide <a data-link-type="dfn" href="#linear-acceleration" id="ref-for-linear-acceleration-1">linear acceleration</a> information.</p>
    <h3 class="heading settled" data-level="5.2" id="accelerometer-options-dictionary"><span class="secno">5.2. </span><span class="content">The AccelerometerOptions Dictionary</span><a class="self-link" href="#accelerometer-options-dictionary"></a></h3>
 <pre class="idl highlight def"><span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-accelerometeroptions">AccelerometerOptions</dfn> :  <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#dictdef-sensoroptions">SensorOptions</a>  {
   <span class="kt">boolean</span> <dfn class="nv idl-code" data-default="true" data-dfn-for="AccelerometerOptions" data-dfn-type="dict-member" data-export="" data-type="boolean " id="dom-accelerometeroptions-includegravity">includeGravity<a class="self-link" href="#dom-accelerometeroptions-includegravity"></a></dfn> = <span class="kt">true</span>;
 };
 </pre>
-   <p>By default, Accelerometer would provide acceleration information including
-the effect of the gravity force. In cases, when <a data-link-type="dfn" href="#linear-acceleration" id="ref-for-linear-acceleration-1">linear acceleration</a> information is
-required, <code class="idl"><a data-link-type="idl" href="#dictdef-accelerometeroptions" id="ref-for-dictdef-accelerometeroptions-2">AccelerometerOptions</a></code> dictionary with and dictionary member <a class="idl-code" data-link-type="attribute">includeGravity</a> that is set to false,
-must be provided to <code class="idl"><a data-link-type="idl" href="#accelerometer" id="ref-for-accelerometer-2">Accelerometer</a></code> constructor.</p>
-   <h3 class="heading settled" data-level="5.3" id="accelerometer-reading-interface"><span class="secno">5.3. </span><span class="content">The AccelerometerReading Interface</span><a class="self-link" href="#accelerometer-reading-interface"></a></h3>
-<pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="AccelerometerReading" data-dfn-type="constructor" data-export="" data-lt="AccelerometerReading(AccelerometerReadingInit)" id="dom-accelerometerreading-accelerometerreading">Constructor<a class="self-link" href="#dom-accelerometerreading-accelerometerreading"></a></dfn>(<a class="n" data-link-type="idl-name" href="#dictdef-accelerometerreadinginit" id="ref-for-dictdef-accelerometerreadinginit-1">AccelerometerReadingInit</a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="AccelerometerReading/AccelerometerReading(AccelerometerReadingInit)" data-dfn-type="argument" data-export="" id="dom-accelerometerreading-accelerometerreading-accelerometerreadinginit-accelerometerreadinginit">AccelerometerReadingInit</dfn>)]
-<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="accelerometerreading">AccelerometerReading</dfn> : <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#sensorreading">SensorReading</a> {
-    <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">double</span> <dfn class="nv dfn-paneled idl-code" data-dfn-for="AccelerometerReading" data-dfn-type="attribute" data-export="" data-readonly="" data-type="double" id="dom-accelerometerreading-x">x</dfn>;
-    <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">double</span> <dfn class="nv dfn-paneled idl-code" data-dfn-for="AccelerometerReading" data-dfn-type="attribute" data-export="" data-readonly="" data-type="double" id="dom-accelerometerreading-y">y</dfn>;
-    <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">double</span> <dfn class="nv dfn-paneled idl-code" data-dfn-for="AccelerometerReading" data-dfn-type="attribute" data-export="" data-readonly="" data-type="double" id="dom-accelerometerreading-z">z</dfn>;
-};
-
-<span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-accelerometerreadinginit">AccelerometerReadingInit</dfn> {
-    <span class="kt">double</span> <dfn class="nv idl-code" data-default="0" data-dfn-for="AccelerometerReadingInit" data-dfn-type="dict-member" data-export="" data-type="double " id="dom-accelerometerreadinginit-x">x<a class="self-link" href="#dom-accelerometerreadinginit-x"></a></dfn> = 0;
-    <span class="kt">double</span> <dfn class="nv idl-code" data-default="0" data-dfn-for="AccelerometerReadingInit" data-dfn-type="dict-member" data-export="" data-type="double " id="dom-accelerometerreadinginit-y">y<a class="self-link" href="#dom-accelerometerreadinginit-y"></a></dfn> = 0;
-    <span class="kt">double</span> <dfn class="nv idl-code" data-default="0" data-dfn-for="AccelerometerReadingInit" data-dfn-type="dict-member" data-export="" data-type="double " id="dom-accelerometerreadinginit-z">z<a class="self-link" href="#dom-accelerometerreadinginit-z"></a></dfn> = 0;
-};
-</pre>
-   <h4 class="heading settled" data-level="5.3.1" id="accelerometer-attributes"><span class="secno">5.3.1. </span><span class="content">The Accelerometer attributes</span><a class="self-link" href="#accelerometer-attributes"></a></h4>
-   <p>The <a class="idl-code" data-link-type="attribute" href="#dom-accelerometer-includesgravity" id="ref-for-dom-accelerometer-includesgravity-1">includesGravity</a> attribute of the <code class="idl"><a data-link-type="idl" href="#accelerometer" id="ref-for-accelerometer-3">Accelerometer</a></code> interface represents whether the acceleration information provided by the sensor includes effect of the gravity
-force. In case when <a class="idl-code" data-link-type="attribute" href="#dom-accelerometer-includesgravity" id="ref-for-dom-accelerometer-includesgravity-2">includesGravity</a> equals to false, <code class="idl"><a data-link-type="idl" href="#accelerometer" id="ref-for-accelerometer-4">Accelerometer</a></code> will provide <a data-link-type="dfn" href="#linear-acceleration" id="ref-for-linear-acceleration-2">linear acceleration</a> information.</p>
-   <h4 class="heading settled" data-level="5.3.2" id="accelerometer-reading-constructor"><span class="secno">5.3.2. </span><span class="content">The AccelerometerReading constructor</span><a class="self-link" href="#accelerometer-reading-constructor"></a></h4>
-   <p>The AccelerometerReading constructor accepts <code class="idl"><a data-link-type="idl" href="#dom-accelerometerreading-accelerometerreading-accelerometerreadinginit-accelerometerreadinginit" id="ref-for-dom-accelerometerreading-accelerometerreading-accelerometerreadinginit-accelerometerreadinginit-1">AccelerometerReadingInit</a></code> dictionary that is used
-for initialization of <code class="idl"><a data-link-type="idl" href="#accelerometerreading" id="ref-for-accelerometerreading-5">AccelerometerReading</a></code> attributes.</p>
-   <h4 class="heading settled" data-level="5.3.3" id="accelerometer-reading-attributes"><span class="secno">5.3.3. </span><span class="content">The AccelerometerReading attributes</span><a class="self-link" href="#accelerometer-reading-attributes"></a></h4>
-   <p>The <a class="idl-code" data-link-type="attribute" href="#dom-accelerometerreading-x" id="ref-for-dom-accelerometerreading-x-2">x</a> attribute of the <code class="idl"><a data-link-type="idl" href="#accelerometerreading" id="ref-for-accelerometerreading-6">AccelerometerReading</a></code> interface represents the <a data-link-type="dfn">acceleration</a> along X-axis.</p>
-   <p>The <a class="idl-code" data-link-type="attribute" href="#dom-accelerometerreading-y" id="ref-for-dom-accelerometerreading-y-2">y</a> attribute of the <code class="idl"><a data-link-type="idl" href="#accelerometerreading" id="ref-for-accelerometerreading-7">AccelerometerReading</a></code> interface represents the <a data-link-type="dfn">acceleration</a> along Y-axis.</p>
-   <p>The <a class="idl-code" data-link-type="attribute" href="#dom-accelerometerreading-z" id="ref-for-dom-accelerometerreading-z-2">z</a> attribute of the <code class="idl"><a data-link-type="idl" href="#accelerometerreading" id="ref-for-accelerometerreading-8">AccelerometerReading</a></code> interface represents the <a data-link-type="dfn">acceleration</a> along Z-axis.</p>
+   <p>By default, accelerometer sensor provides <a data-link-type="dfn" href="#acceleration" id="ref-for-acceleration-11">acceleration</a> information including the effect of the gravity force.
+In cases when <a data-link-type="dfn" href="#linear-acceleration" id="ref-for-linear-acceleration-2">linear acceleration</a> information is required, <code class="idl"><a data-link-type="idl" href="#dictdef-accelerometeroptions" id="ref-for-dictdef-accelerometeroptions-2">AccelerometerOptions</a></code> dictionary
+must include an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry">entry</a> whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-key">key</a> is "includeGravity" and whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-value">value</a> is false.</p>
    <h2 class="heading settled" data-level="6" id="acknowledgements"><span class="secno">6. </span><span class="content">Acknowledgements</span><a class="self-link" href="#acknowledgements"></a></h2>
    <p>Tobie Langel for the work on Generic Sensor API.</p>
    <h2 class="heading settled" data-level="7" id="conformance"><span class="secno">7. </span><span class="content">Conformance</span><a class="self-link" href="#conformance"></a></h2>
@@ -1618,40 +1610,20 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
   <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
   <ul class="index">
+   <li><a href="#acceleration">acceleration</a><span>, in §4</span>
    <li><a href="#accelerometer">Accelerometer</a><span>, in §5.1</span>
    <li><a href="#dom-accelerometer-accelerometer">Accelerometer()</a><span>, in §5.1</span>
    <li><a href="#dom-accelerometer-accelerometer">Accelerometer(accelerometerOptions)</a><span>, in §5.1</span>
    <li><a href="#dictdef-accelerometeroptions">AccelerometerOptions</a><span>, in §5.2</span>
-   <li><a href="#accelerometerreading">AccelerometerReading</a><span>, in §5.3</span>
-   <li><a href="#dom-accelerometerreading-accelerometerreading">AccelerometerReading(AccelerometerReadingInit)</a><span>, in §5.3</span>
-   <li><a href="#dictdef-accelerometerreadinginit">AccelerometerReadingInit</a><span>, in §5.3</span>
    <li><a href="#conformant-user-agent">conformant user agent</a><span>, in §7</span>
    <li><a href="#construct-an-accelerometer-object">Construct an Accelerometer Object</a><span>, in §5.1</span>
-   <li><a href="#construct-sensorreading-object">Construct SensorReading Object</a><span>, in §4</span>
    <li><a href="#dom-accelerometeroptions-includegravity">includeGravity</a><span>, in §5.2</span>
    <li><a href="#dom-accelerometer-includesgravity">includesGravity</a><span>, in §5.1</span>
    <li><a href="#linear-acceleration">linear acceleration</a><span>, in §4</span>
    <li><a href="#local-coordinate-system">local coordinate system</a><span>, in §4</span>
-   <li><a href="#dom-accelerometer-reading">reading</a><span>, in §5.1</span>
-   <li><a href="#retrieve-the-sensor-permission">retrieve the sensor permission</a><span>, in §4</span>
-   <li>
-    x
-    <ul>
-     <li><a href="#dom-accelerometerreading-x">attribute for AccelerometerReading</a><span>, in §5.3</span>
-     <li><a href="#dom-accelerometerreadinginit-x">dict-member for AccelerometerReadingInit</a><span>, in §5.3</span>
-    </ul>
-   <li>
-    y
-    <ul>
-     <li><a href="#dom-accelerometerreading-y">attribute for AccelerometerReading</a><span>, in §5.3</span>
-     <li><a href="#dom-accelerometerreadinginit-y">dict-member for AccelerometerReadingInit</a><span>, in §5.3</span>
-    </ul>
-   <li>
-    z
-    <ul>
-     <li><a href="#dom-accelerometerreading-z">attribute for AccelerometerReading</a><span>, in §5.3</span>
-     <li><a href="#dom-accelerometerreadinginit-z">dict-member for AccelerometerReadingInit</a><span>, in §5.3</span>
-    </ul>
+   <li><a href="#dom-accelerometer-x">x</a><span>, in §5.1</span>
+   <li><a href="#dom-accelerometer-y">y</a><span>, in §5.1</span>
+   <li><a href="#dom-accelerometer-z">z</a><span>, in §5.1</span>
   </ul>
   <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
   <ul class="index">
@@ -1660,35 +1632,34 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
     <ul>
      <li><a href="https://w3c.github.io/sensors#construct-sensor-object">construct a sensor object</a>
      <li><a href="https://w3c.github.io/sensors#default-sensor">default sensor</a>
-     <li><a href="https://w3c.github.io/sensors#sensor-subclass">sensor subclass</a>
-     <li><a href="https://w3c.github.io/sensors#sensorreading-subclass">sensorreading subclass</a>
-     <li><a href="https://w3c.github.io/sensors#supported-reporting-modes">supported reporting mode</a>
-    </ul>
-   <li>
-    <a data-link-type="biblio">[permissions]</a> defines the following terms:
-    <ul>
-     <li><a href="https://w3c.github.io/permissions/#dfn-associated-permissiondescriptor">associated permissiondescriptor</a>
-     <li><a href="https://w3c.github.io/permissions/#idl-def-Permission">permission</a>
+     <li><a href="https://w3c.github.io/sensors#latest-reading">latest reading</a>
+     <li><a href="https://w3c.github.io/sensors#sensor">sensor</a>
     </ul>
    <li>
     <a data-link-type="biblio">[GENERIC-SENSOR]</a> defines the following terms:
     <ul>
      <li><a href="https://w3c.github.io/sensors/#sensor">Sensor</a>
      <li><a href="https://w3c.github.io/sensors/#dictdef-sensoroptions">SensorOptions</a>
-     <li><a href="https://w3c.github.io/sensors/#sensorreading">SensorReading</a>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[INFRA]</a> defines the following terms:
+    <ul>
+     <li><a href="https://infra.spec.whatwg.org/#map-entry">entry</a>
+     <li><a href="https://infra.spec.whatwg.org/#map-key">key</a>
+     <li><a href="https://infra.spec.whatwg.org/#map-value">value</a>
     </ul>
   </ul>
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
   <h3 class="no-num no-ref heading settled" id="normative"><span class="content">Normative References</span><a class="self-link" href="#normative"></a></h3>
   <dl>
    <dt id="biblio-generic-sensor">[GENERIC-SENSOR]
-   <dd>Tobie Langel; Rick Waldron. <a href="https://w3c.github.io/sensors/">Generic Sensor API</a>. 24 March 2016. WD. URL: <a href="https://w3c.github.io/sensors/">https://w3c.github.io/sensors/</a>
-   <dt id="biblio-permissions">[PERMISSIONS]
-   <dd>Mounir Lamouri; Marcos Caceres. <a href="https://w3c.github.io/permissions/">The Permissions API</a>. 7 April 2015. WD. URL: <a href="https://w3c.github.io/permissions/">https://w3c.github.io/permissions/</a>
+   <dd>Tobie Langel; Rick Waldron. <a href="https://w3c.github.io/sensors/">Generic Sensor API</a>. 30 August 2016. WD. URL: <a href="https://w3c.github.io/sensors/">https://w3c.github.io/sensors/</a>
+   <dt id="biblio-infra">[INFRA]
+   <dd>Anne van Kesteren; Domenic Denicola. <a href="https://infra.spec.whatwg.org/">Infra Standard</a>. Living Standard. URL: <a href="https://infra.spec.whatwg.org/">https://infra.spec.whatwg.org/</a>
    <dt id="biblio-rfc2119">[RFC2119]
    <dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a>
    <dt id="biblio-webidl">[WEBIDL]
-   <dd>Cameron McCormack; Boris Zbarsky. <a href="https://heycam.github.io/webidl/">WebIDL Level 1</a>. 8 March 2016. CR. URL: <a href="https://heycam.github.io/webidl/">https://heycam.github.io/webidl/</a>
+   <dd>Cameron McCormack; Boris Zbarsky; Tobie Langel. <a href="https://heycam.github.io/webidl/">Web IDL</a>. 15 December 2016. WD. URL: <a href="https://heycam.github.io/webidl/">https://heycam.github.io/webidl/</a>
   </dl>
   <h3 class="no-num no-ref heading settled" id="informative"><span class="content">Informative References</span><a class="self-link" href="#informative"></a></h3>
   <dl>
@@ -1698,7 +1669,9 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
   <h2 class="no-num no-ref heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>
 <pre class="idl def">[<a class="nv" href="#dom-accelerometer-accelerometer">Constructor</a>(<span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-accelerometeroptions">AccelerometerOptions</a> <a class="nv" href="#dom-accelerometer-accelerometer-accelerometeroptions-accelerometeroptions">accelerometerOptions</a>)]
 <span class="kt">interface</span> <a class="nv" href="#accelerometer">Accelerometer</a> : <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#sensor">Sensor</a> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#accelerometerreading">AccelerometerReading</a>? <a class="nv" data-readonly="" data-type="AccelerometerReading?" href="#dom-accelerometer-reading">reading</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">unrestricted</span> <span class="kt">double</span>? <a class="nv" data-readonly="" data-type="unrestricted double?" href="#dom-accelerometer-x">x</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">unrestricted</span> <span class="kt">double</span>? <a class="nv" data-readonly="" data-type="unrestricted double?" href="#dom-accelerometer-y">y</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">unrestricted</span> <span class="kt">double</span>? <a class="nv" data-readonly="" data-type="unrestricted double?" href="#dom-accelerometer-z">z</a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">boolean</span> <a class="nv" data-readonly="" data-type="boolean" href="#dom-accelerometer-includesgravity">includesGravity</a>;
 };
 
@@ -1706,46 +1679,65 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
   <span class="kt">boolean</span> <a class="nv" data-default="true" data-type="boolean " href="#dom-accelerometeroptions-includegravity">includeGravity</a> = <span class="kt">true</span>;
 };
 
-[<a class="nv" href="#dom-accelerometerreading-accelerometerreading">Constructor</a>(<a class="n" data-link-type="idl-name" href="#dictdef-accelerometerreadinginit">AccelerometerReadingInit</a> <a class="nv" href="#dom-accelerometerreading-accelerometerreading-accelerometerreadinginit-accelerometerreadinginit">AccelerometerReadingInit</a>)]
-<span class="kt">interface</span> <a class="nv" href="#accelerometerreading">AccelerometerReading</a> : <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#sensorreading">SensorReading</a> {
-    <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">double</span> <a class="nv" data-readonly="" data-type="double" href="#dom-accelerometerreading-x">x</a>;
-    <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">double</span> <a class="nv" data-readonly="" data-type="double" href="#dom-accelerometerreading-y">y</a>;
-    <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">double</span> <a class="nv" data-readonly="" data-type="double" href="#dom-accelerometerreading-z">z</a>;
-};
-
-<span class="kt">dictionary</span> <a class="nv" href="#dictdef-accelerometerreadinginit">AccelerometerReadingInit</a> {
-    <span class="kt">double</span> <a class="nv" data-default="0" data-type="double " href="#dom-accelerometerreadinginit-x">x</a> = 0;
-    <span class="kt">double</span> <a class="nv" data-default="0" data-type="double " href="#dom-accelerometerreadinginit-y">y</a> = 0;
-    <span class="kt">double</span> <a class="nv" data-default="0" data-type="double " href="#dom-accelerometerreadinginit-z">z</a> = 0;
-};
-
 </pre>
-  <aside class="dfn-panel" data-for="linear-acceleration">
-   <b><a href="#linear-acceleration">#linear-acceleration</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="acceleration">
+   <b><a href="#acceleration">#acceleration</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-linear-acceleration-1">5.2. The AccelerometerOptions Dictionary</a>
-    <li><a href="#ref-for-linear-acceleration-2">5.3.1. The Accelerometer attributes</a>
+    <li><a href="#ref-for-acceleration-1">1. Introduction</a>
+    <li><a href="#ref-for-acceleration-2">4. Model</a> <a href="#ref-for-acceleration-3">(2)</a> <a href="#ref-for-acceleration-4">(3)</a> <a href="#ref-for-acceleration-5">(4)</a> <a href="#ref-for-acceleration-6">(5)</a>
+    <li><a href="#ref-for-acceleration-7">5.1.1. Accelerometer.x</a>
+    <li><a href="#ref-for-acceleration-8">5.1.2. Accelerometer.y</a>
+    <li><a href="#ref-for-acceleration-9">5.1.3. Accelerometer.z</a>
+    <li><a href="#ref-for-acceleration-10">5.1.4. Accelerometer.includesGravity</a>
+    <li><a href="#ref-for-acceleration-11">5.2. The AccelerometerOptions Dictionary</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="local-coordinate-system">
    <b><a href="#local-coordinate-system">#local-coordinate-system</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-local-coordinate-system-1">1. Introduction</a>
-    <li><a href="#ref-for-local-coordinate-system-2">4. Model</a> <a href="#ref-for-local-coordinate-system-3">(2)</a>
+    <li><a href="#ref-for-local-coordinate-system-2">4. Model</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="linear-acceleration">
+   <b><a href="#linear-acceleration">#linear-acceleration</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-linear-acceleration-1">5.1.4. Accelerometer.includesGravity</a>
+    <li><a href="#ref-for-linear-acceleration-2">5.2. The AccelerometerOptions Dictionary</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="accelerometer">
    <b><a href="#accelerometer">#accelerometer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-accelerometer-1">4. Model</a>
-    <li><a href="#ref-for-accelerometer-2">5.2. The AccelerometerOptions Dictionary</a>
-    <li><a href="#ref-for-accelerometer-3">5.3.1. The Accelerometer attributes</a> <a href="#ref-for-accelerometer-4">(2)</a>
+    <li><a href="#ref-for-accelerometer-2">5.1.1. Accelerometer.x</a>
+    <li><a href="#ref-for-accelerometer-3">5.1.2. Accelerometer.y</a>
+    <li><a href="#ref-for-accelerometer-4">5.1.3. Accelerometer.z</a>
+    <li><a href="#ref-for-accelerometer-5">5.1.4. Accelerometer.includesGravity</a> <a href="#ref-for-accelerometer-6">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-accelerometer-x">
+   <b><a href="#dom-accelerometer-x">#dom-accelerometer-x</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-accelerometer-x-1">5.1.1. Accelerometer.x</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-accelerometer-y">
+   <b><a href="#dom-accelerometer-y">#dom-accelerometer-y</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-accelerometer-y-1">5.1.2. Accelerometer.y</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-accelerometer-z">
+   <b><a href="#dom-accelerometer-z">#dom-accelerometer-z</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-accelerometer-z-1">5.1.3. Accelerometer.z</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-accelerometer-includesgravity">
    <b><a href="#dom-accelerometer-includesgravity">#dom-accelerometer-includesgravity</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-accelerometer-includesgravity-1">5.3.1. The Accelerometer attributes</a> <a href="#ref-for-dom-accelerometer-includesgravity-2">(2)</a>
+    <li><a href="#ref-for-dom-accelerometer-includesgravity-1">5.1.4. Accelerometer.includesGravity</a> <a href="#ref-for-dom-accelerometer-includesgravity-2">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dictdef-accelerometeroptions">
@@ -1753,48 +1745,6 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
    <ul>
     <li><a href="#ref-for-dictdef-accelerometeroptions-1">5.1. The Accelerometer Interface</a>
     <li><a href="#ref-for-dictdef-accelerometeroptions-2">5.2. The AccelerometerOptions Dictionary</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="dom-accelerometerreading-accelerometerreading-accelerometerreadinginit-accelerometerreadinginit">
-   <b><a href="#dom-accelerometerreading-accelerometerreading-accelerometerreadinginit-accelerometerreadinginit">#dom-accelerometerreading-accelerometerreading-accelerometerreadinginit-accelerometerreadinginit</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-dom-accelerometerreading-accelerometerreading-accelerometerreadinginit-accelerometerreadinginit-1">5.3.2. The AccelerometerReading constructor</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="accelerometerreading">
-   <b><a href="#accelerometerreading">#accelerometerreading</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-accelerometerreading-1">4. Model</a> <a href="#ref-for-accelerometerreading-2">(2)</a> <a href="#ref-for-accelerometerreading-3">(3)</a>
-    <li><a href="#ref-for-accelerometerreading-4">5.1. The Accelerometer Interface</a>
-    <li><a href="#ref-for-accelerometerreading-5">5.3.2. The AccelerometerReading constructor</a>
-    <li><a href="#ref-for-accelerometerreading-6">5.3.3. The AccelerometerReading attributes</a> <a href="#ref-for-accelerometerreading-7">(2)</a> <a href="#ref-for-accelerometerreading-8">(3)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="dom-accelerometerreading-x">
-   <b><a href="#dom-accelerometerreading-x">#dom-accelerometerreading-x</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-dom-accelerometerreading-x-1">4. Model</a>
-    <li><a href="#ref-for-dom-accelerometerreading-x-2">5.3.3. The AccelerometerReading attributes</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="dom-accelerometerreading-y">
-   <b><a href="#dom-accelerometerreading-y">#dom-accelerometerreading-y</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-dom-accelerometerreading-y-1">4. Model</a>
-    <li><a href="#ref-for-dom-accelerometerreading-y-2">5.3.3. The AccelerometerReading attributes</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="dom-accelerometerreading-z">
-   <b><a href="#dom-accelerometerreading-z">#dom-accelerometerreading-z</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-dom-accelerometerreading-z-1">4. Model</a>
-    <li><a href="#ref-for-dom-accelerometerreading-z-2">5.3.3. The AccelerometerReading attributes</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="dictdef-accelerometerreadinginit">
-   <b><a href="#dictdef-accelerometerreadinginit">#dictdef-accelerometerreadinginit</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-dictdef-accelerometerreadinginit-1">5.3. The AccelerometerReading Interface</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */


### PR DESCRIPTION
This patch aligns Accelerometer interface with the latest changes in Generic Sensor API.
AccelerometerReading interface is removed and sensor reading values are exposed on main
Accelerometer interface using "latest reading" terminology from Generic Sensor API [1].

[1] https://w3c.github.io/sensors/#latest-reading