### PR TITLE
Split Accelerometer interface

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5,12 +5,12 @@ Status: ED
 ED: https://w3c.github.io/accelerometer/
 Shortname: accelerometer
 TR: https://www.w3.org/TR/accelerometer/
-Editor: Anssi Kostiainen 41974, Intel Corporation, https://intel.com/
-Editor: Alexander Shalamov 78335, Intel Corporation, https://intel.com/
+Editor: Anssi Kostiainen 41974, Intel Corporation, http://intel.com/
+Editor: Alexander Shalamov 78335, Intel Corporation, http://intel.com/
 Group: dap
 Abstract:
-  This specification defines accelerometer sensor interface for
-  obtaining information about <a>acceleration</a> applied to the X, Y and Z axis
+  This specification defines {{Accelerometer}}, {{LinearAccelerationSensor}} and {{GravitySensor}} interfaces for
+  obtaining information about [=acceleration=] applied to the X, Y and Z axis
   of a device that hosts the sensor.
 Version History: https://github.com/w3c/accelerometer/commits/gh-pages/index.bs
 !Bug Reports: <a href="https://www.github.com/w3c/accelerometer/issues/new">via the w3c/accelerometer repository on GitHub</a>
@@ -36,9 +36,9 @@ urlPrefix: https://w3c.github.io/sensors; spec: GENERIC-SENSOR
 Introduction {#intro}
 ============
 
-The Accelerometer API extends the Generic Sensor API [[GENERIC-SENSOR]]
-interface to provide information about <a>acceleration</a> applied to device's
-X, Y and Z axis in <a>local coordinate system</a> defined by device.
+The {{Accelerometer}}, {{LinearAccelerationSensor}} and {{GravitySensor}} APIs extends the Generic Sensor API [[GENERIC-SENSOR]]
+interface to provide information about [=acceleration=] applied to device's
+X, Y and Z axis in [=local coordinate system=] defined by device.
 
 Examples {#examples}
 ========
@@ -69,28 +69,37 @@ Model {#model}
 
 The accelerometer's associated {{Sensor}} subclass is the {{Accelerometer}} class.
 
-Accelerometer has a <a>default sensor</a>, which is the device's main accelerometer sensor.
+Accelerometer has a [=default sensor=], which is the device's main accelerometer sensor.
 
 A [=latest reading=] per [=sensor=] of accelerometer type includes three [=map/entries=]
-whose [=map/keys=] are "x", "y", "z" and whose [=map/values=] contain device's <a>acceleration</a>
-about the corresponding axes.
+whose [=map/keys=] are "x", "y", "z" and whose [=map/values=] contain device's [=acceleration=]
+about the corresponding axes. Values can contain also device's [=linear acceleration=] or [=gravity=]
+depending on which object was instantiated.
 
 The <dfn>acceleration</dfn> is the rate of change of velocity of a device with respect to time. Its 
-unit is the metre per second squared (m/s^2) [[SI]].
+unit is the metre per second squared (m/s<sup>2</sup>) [[SI]].
 
-The frame of reference for the <a>acceleration</a> measurement must be inertial, such as, the device in free fall would
-provide 0 (m/s^2) <a>acceleration</a> value for each axis.
+The frame of reference for the [=acceleration=] measurement must be inertial, such as, the device in free fall would
+provide 0 (m/s<sup>2</sup>) [=acceleration=] value for each axis.
 
-The sign of the <a>acceleration</a> values must be according to the right-hand convention in a <a>local coordinate
-system</a> defined by the device.
+The sign of the [=acceleration=] values must be according to the right-hand convention in a [=local coordinate
+system=] defined by the device.
+
+The {{LinearAccelerationSensor}} class is an {{Accelerometer}}'s subclass. The {{LinearAccelerationSensor}}'s
+[=latest reading=] contains device's [=linear acceleration=] about the corresponding axes.
+
+The <dfn>linear acceleration</dfn> is an [=acceleration=] that is applied to the device that hosts
+the sensor, without the contribution of a [=gravity=] force.
+
+The {{GravitySensor}} class is an {{Accelerometer}}'s subclass. The {{GravitySensor}}'s
+[=latest reading=] contains device's [=acceleration=] due to the effect of [=gravity=] force about the corresponding axes.
+
+The <dfn>gravity</dfn> is a force that attracts an object to the center of the earth, or towards any other physical object having mass.
 
 Note: The <dfn>local coordinate system</dfn> of a mobile device is usually defined relative to
 the device's screen when the device in its default orientation (see figure below).
 
-<img src="accelerometer_coordinate_system.png" srcset="accelerometer_coordinate_system.svg" alt="Accelerometer coordinate system.">
-
-The <dfn>linear acceleration</dfn> is an <a>acceleration</a> that is applied to the device that hosts
-the sensor, without the contribution of a gravity force.
+<img src="accelerometer_coordinate_system.png" srcset="accelerometer_coordinate_system.svg" style="display: block;margin: auto;" alt="Accelerometer coordinate system.">
 
 API {#api}
 ===
@@ -99,55 +108,94 @@ The Accelerometer Interface {#accelerometer-interface}
 --------------------------------
 
 <pre class="idl">
-  [Constructor(optional AccelerometerOptions accelerometerOptions)]
+  [Constructor(optional SensorOptions options)]
   interface Accelerometer : Sensor {
     readonly attribute unrestricted double? x;
     readonly attribute unrestricted double? y;
     readonly attribute unrestricted double? z;
-    readonly attribute boolean includesGravity;
   };
 </pre>
 
 To <dfn>Construct an Accelerometer Object</dfn> the user agent must invoke
-the <a>construct a Sensor object</a> abstract operation.
+the [=construct a Sensor object=] abstract operation.
 
 ### Accelerometer.x ### {#accelerometer-x}
 
 The {{Accelerometer/x!!attribute}} attribute of the {{Accelerometer}}
-interface represents the <a>acceleration</a> along X-axis.
+interface represents the [=acceleration=] along x-axis.
 This attribute returns [=map/value=] for [=latest reading=]["x"] [=map/entry=].
 
 ### Accelerometer.y ### {#accelerometer-y}
 
 The {{Accelerometer/y!!attribute}} attribute of the {{Accelerometer}}
-interface represents the <a>acceleration</a> along Y-axis.
+interface represents the [=acceleration=] along y-axis.
 This attribute returns [=map/value=] for [=latest reading=]["y"] [=map/entry=].
 
 ### Accelerometer.z ### {#accelerometer-z}
 
 The {{Accelerometer/z!!attribute}} attribute of the {{Accelerometer}}
-interface represents the <a>acceleration</a> along Z-axis.
+interface represents the [=acceleration=] along z-axis.
 This attribute returns [=map/value=] for [=latest reading=]["z"] [=map/entry=].
 
-### Accelerometer.includesGravity ### {#accelerometer-includesGravity}
-
-The {{Accelerometer/includesGravity!!attribute}} attribute of the {{Accelerometer}}
-interface represents whether the <a>acceleration</a> information provided by the sensor includes the effect of the gravity
-force. In case when {{Accelerometer/includesGravity!!attribute}} equals to false, {{Accelerometer}}
-will provide <a>linear acceleration</a> information.
-
-The AccelerometerOptions Dictionary {#accelerometer-options-dictionary}
+The LinearAccelerationSensor Interface {#linear-accelerometer-interface}
 --------------------------------
 
 <pre class="idl">
-  dictionary AccelerometerOptions :  SensorOptions  {
-    boolean includeGravity = true;
+  [Constructor(optional SensorOptions options)]
+  interface LinearAccelerationSensor : Accelerometer {
   };
 </pre>
 
-By default, accelerometer sensor provides <a>acceleration</a> information including the effect of the gravity force.
-In cases when <a>linear acceleration</a> information is required, {{AccelerometerOptions}} dictionary
-must include an [=map/entry=] whose [=map/key=] is "includeGravity" and whose [=map/value=] is false.
+To <dfn>Construct a LinearAccelerationSensor Object</dfn> the user agent must invoke
+the [=construct a Sensor object=] abstract operation.
+
+### LinearAccelerationSensor.x ### {#linearaccelerationsensor-x}
+
+The {{Accelerometer/x!!attribute}} attribute of the {{LinearAccelerationSensor}}
+interface represents the [=linear acceleration=] along x-axis.
+This attribute returns [=map/value=] for [=latest reading=]["x"] [=map/entry=].
+
+### LinearAccelerationSensor.y ### {#linearaccelerationsensor-y}
+
+The {{Accelerometer/y!!attribute}} attribute of the {{LinearAccelerationSensor}}
+interface represents the [=linear acceleration=] along y-axis.
+This attribute returns [=map/value=] for [=latest reading=]["y"] [=map/entry=].
+
+### LinearAccelerationSensor.z ### {#linearaccelerationsensor-z}
+
+The {{Accelerometer/z!!attribute}} attribute of the {{LinearAccelerationSensor}}
+interface represents the [=linear acceleration=] along z-axis.
+This attribute returns [=map/value=] for [=latest reading=]["z"] [=map/entry=].
+
+The GravitySensor Interface {#gravity-sensor-interface}
+--------------------------------
+
+<pre class="idl">
+  [Constructor(optional SensorOptions options)]
+  interface GravitySensor : Accelerometer {
+  };
+</pre>
+
+To <dfn>Construct an GravitySensor Object</dfn> the user agent must invoke
+the [=construct a Sensor object=] abstract operation.
+
+### GravitySensor.x ### {#gravitysensor-x}
+
+The {{Accelerometer/x!!attribute}} attribute of the {{GravitySensor}}
+interface represents the effect of [=acceleration=] along x-axis due to [=gravity=].
+This attribute returns [=map/value=] for [=latest reading=]["x"] [=map/entry=].
+
+### GravitySensor.y ### {#gravitysensor-y}
+
+The {{Accelerometer/y!!attribute}} attribute of the {{GravitySensor}}
+interface represents the effect of [=acceleration=] along y-axis due to [=gravity=].
+This attribute returns [=map/value=] for [=latest reading=]["y"] [=map/entry=].
+
+### GravitySensor.z ### {#gravitysensor-z}
+
+The {{Accelerometer/z!!attribute}} attribute of the {{GravitySensor}}
+interface represents the effect of [=acceleration=] along z-axis due to [=gravity=].
+This attribute returns [=map/value=] for [=latest reading=]["z"] [=map/entry=].
 
 Acknowledgements {#acknowledgements}
 ================

--- a/index.html
+++ b/index.html
@@ -419,7 +419,7 @@
 	[data-algorithm]:not(.heading) {
 	  padding: .5em;
 	  border: thin solid #ddd; border-radius: .5em;
-	  margin: .5em 0;
+	  margin: .5em calc(-0.5em - 1px);
 	}
 	[data-algorithm]:not(.heading) > :first-child {
 	  margin-top: 0;
@@ -969,6 +969,8 @@ Possible extra rowspan handling
 		/* Reverse color scheme */
 		color: black;
 		border-color: #3980B5;
+		border-bottom-width: 3px !important;
+		margin-bottom: 0px !important;
 	}
 	.toc a:visited {
 		border-color: #054572;
@@ -1181,7 +1183,7 @@ Possible extra rowspan handling
       background-attachment: fixed;
     }
   </style>
-  <meta content="Bikeshed 1.0.0" name="generator">
+  <meta content="Bikeshed version a65093ce3e69a8d01029b4650499d152cd9bd39a" name="generator">
 <style>/* style-md-lists */
 
             /* This is a weird hack for me not yet following the commonmark spec
@@ -1426,9 +1428,9 @@ pre.idl.highlight { color: #708090; }
         </style>
  <body class="h-entry">
   <div class="head">
-   <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
+   <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Accelerometer</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-02-02">2 February 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-03-15">15 March 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1442,8 +1444,8 @@ pre.idl.highlight { color: #708090; }
      <dt>Issue Tracking:
      <dd><a href="https://github.com/w3c/accelerometer/issues/">GitHub</a>
      <dt class="editor">Editors:
-     <dd class="editor p-author h-card vcard" data-editor-id="41974"><a class="p-name fn u-url url" href="https://intel.com/">Anssi Kostiainen</a> (<span class="p-org org">Intel Corporation</span>)
-     <dd class="editor p-author h-card vcard" data-editor-id="78335"><a class="p-name fn u-url url" href="https://intel.com/">Alexander Shalamov</a> (<span class="p-org org">Intel Corporation</span>)
+     <dd class="editor p-author h-card vcard" data-editor-id="41974"><a class="p-name fn u-url url" href="http://intel.com/">Anssi Kostiainen</a> (<span class="p-org org">Intel Corporation</span>)
+     <dd class="editor p-author h-card vcard" data-editor-id="78335"><a class="p-name fn u-url url" href="http://intel.com/">Alexander Shalamov</a> (<span class="p-org org">Intel Corporation</span>)
      <dt>Bug Reports:
      <dd><span><a href="https://www.github.com/w3c/accelerometer/issues/new">via the w3c/accelerometer repository on GitHub</a></span>
      <dt>Test Suite:
@@ -1456,7 +1458,7 @@ pre.idl.highlight { color: #708090; }
   </div>
   <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>
   <div class="p-summary" data-fill-with="abstract">
-   <p>This specification defines accelerometer sensor interface for
+   <p>This specification defines <code class="idl"><a data-link-type="idl" href="#accelerometer">Accelerometer</a></code>, <code class="idl"><a data-link-type="idl" href="#linearaccelerationsensor">LinearAccelerationSensor</a></code> and <code class="idl"><a data-link-type="idl" href="#gravitysensor">GravitySensor</a></code> interfaces for
 
 obtaining information about <a data-link-type="dfn" href="#acceleration">acceleration</a> applied to the X, Y and Z axis
 of a device that hosts the sensor.</p>
@@ -1479,7 +1481,7 @@ of a device that hosts the sensor.</p>
 	W3C maintains a <a href="https://www.w3.org/2004/01/pp-impl/43696/status" rel="disclosure">public list of any patent disclosures</a> made in connection with the deliverables of the group;
 	that page also includes instructions for disclosing a patent.
 	An individual who has actual knowledge of a patent which the individual believes contains <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential">Essential Claim(s)</a> must disclose the information in accordance with <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#sec-Disclosure">section 6 of the W3C Patent Policy</a>. </p>
-   <p> This document is governed by the <a href="http://www.w3.org/2015/Process-20150901/" id="w3c_process_revision">1 September 2015 W3C Process Document</a>. </p>
+   <p> This document is governed by the <a href="https://www.w3.org/2017/Process-20170301/" id="w3c_process_revision">1 March 2017 W3C Process Document</a>. </p>
    <p></p>
   </div>
   <div data-fill-with="at-risk"></div>
@@ -1499,9 +1501,21 @@ of a device that hosts the sensor.</p>
         <li><a href="#accelerometer-x"><span class="secno">5.1.1</span> <span class="content">Accelerometer.x</span></a>
         <li><a href="#accelerometer-y"><span class="secno">5.1.2</span> <span class="content">Accelerometer.y</span></a>
         <li><a href="#accelerometer-z"><span class="secno">5.1.3</span> <span class="content">Accelerometer.z</span></a>
-        <li><a href="#accelerometer-includesGravity"><span class="secno">5.1.4</span> <span class="content">Accelerometer.includesGravity</span></a>
        </ol>
-      <li><a href="#accelerometer-options-dictionary"><span class="secno">5.2</span> <span class="content">The AccelerometerOptions Dictionary</span></a>
+      <li>
+       <a href="#linear-accelerometer-interface"><span class="secno">5.2</span> <span class="content">The LinearAccelerationSensor Interface</span></a>
+       <ol class="toc">
+        <li><a href="#linearaccelerationsensor-x"><span class="secno">5.2.1</span> <span class="content">LinearAccelerationSensor.x</span></a>
+        <li><a href="#linearaccelerationsensor-y"><span class="secno">5.2.2</span> <span class="content">LinearAccelerationSensor.y</span></a>
+        <li><a href="#linearaccelerationsensor-z"><span class="secno">5.2.3</span> <span class="content">LinearAccelerationSensor.z</span></a>
+       </ol>
+      <li>
+       <a href="#gravity-sensor-interface"><span class="secno">5.3</span> <span class="content">The GravitySensor Interface</span></a>
+       <ol class="toc">
+        <li><a href="#gravitysensor-x"><span class="secno">5.3.1</span> <span class="content">GravitySensor.x</span></a>
+        <li><a href="#gravitysensor-y"><span class="secno">5.3.2</span> <span class="content">GravitySensor.y</span></a>
+        <li><a href="#gravitysensor-z"><span class="secno">5.3.3</span> <span class="content">GravitySensor.z</span></a>
+       </ol>
      </ol>
     <li><a href="#acknowledgements"><span class="secno">6</span> <span class="content">Acknowledgements</span></a>
     <li><a href="#conformance"><span class="secno">7</span> <span class="content">Conformance</span></a>
@@ -1522,7 +1536,7 @@ of a device that hosts the sensor.</p>
   </nav>
   <main>
    <h2 class="heading settled" data-level="1" id="intro"><span class="secno">1. </span><span class="content">Introduction</span><a class="self-link" href="#intro"></a></h2>
-   <p>The Accelerometer API extends the Generic Sensor API <a data-link-type="biblio" href="#biblio-generic-sensor">[GENERIC-SENSOR]</a> interface to provide information about <a data-link-type="dfn" href="#acceleration" id="ref-for-acceleration-1">acceleration</a> applied to device’s
+   <p>The <code class="idl"><a data-link-type="idl" href="#accelerometer" id="ref-for-accelerometer-1">Accelerometer</a></code>, <code class="idl"><a data-link-type="idl" href="#linearaccelerationsensor" id="ref-for-linearaccelerationsensor-1">LinearAccelerationSensor</a></code> and <code class="idl"><a data-link-type="idl" href="#gravitysensor" id="ref-for-gravitysensor-1">GravitySensor</a></code> APIs extends the Generic Sensor API <a data-link-type="biblio" href="#biblio-generic-sensor">[GENERIC-SENSOR]</a> interface to provide information about <a data-link-type="dfn" href="#acceleration" id="ref-for-acceleration-1">acceleration</a> applied to device’s
 X, Y and Z axis in <a data-link-type="dfn" href="#local-coordinate-system" id="ref-for-local-coordinate-system-1">local coordinate system</a> defined by device.</p>
    <h2 class="heading settled" data-level="2" id="examples"><span class="secno">2. </span><span class="content">Examples</span><a class="self-link" href="#examples"></a></h2>
    <div class="example" id="example-a773d78c">
@@ -1530,65 +1544,88 @@ X, Y and Z axis in <a data-link-type="dfn" href="#local-coordinate-system" id="r
 <pre class="highlight"><span class="kd">let</span> sensor <span class="o">=</span> <span class="k">new</span> Accelerometer<span class="p">(</span><span class="p">)</span><span class="p">;</span>
 sensor<span class="p">.</span>start<span class="p">(</span><span class="p">)</span><span class="p">;</span>
 
-sensor<span class="p">.</span>onchange <span class="o">=</span> <span class="p">(</span><span class="p">)</span> <span class="o">=></span> <span class="p">{</span>
+sensor<span class="p">.</span>onchange <span class="o">=</span> <span class="p">(</span><span class="p">)</span> <span class="p">=></span> <span class="p">{</span>
     console<span class="p">.</span>log<span class="p">(</span><span class="s2">"Acceleration along X-axis: "</span> <span class="o">+</span> sensor<span class="p">.</span>x<span class="p">)</span><span class="p">;</span>
     console<span class="p">.</span>log<span class="p">(</span><span class="s2">"Acceleration along Y-axis: "</span> <span class="o">+</span> sensor<span class="p">.</span>y<span class="p">)</span><span class="p">;</span>
     console<span class="p">.</span>log<span class="p">(</span><span class="s2">"Acceleration along Z-axis: "</span> <span class="o">+</span> sensor<span class="p">.</span>z<span class="p">)</span><span class="p">;</span>
 <span class="p">}</span>
 
-sensor<span class="p">.</span>onerror <span class="o">=</span> event <span class="o">=></span> console<span class="p">.</span>log<span class="p">(</span>event<span class="p">.</span>error<span class="p">.</span>name<span class="p">,</span> event<span class="p">.</span>error<span class="p">.</span>message<span class="p">)</span><span class="p">;</span>
+sensor<span class="p">.</span>onerror <span class="o">=</span> event <span class="p">=></span> console<span class="p">.</span>log<span class="p">(</span>event<span class="p">.</span>error<span class="p">.</span>name<span class="p">,</span> event<span class="p">.</span>error<span class="p">.</span>message<span class="p">)</span><span class="p">;</span>
 </pre>
    </div>
    <h2 class="heading settled" data-level="3" id="security-and-privacy"><span class="secno">3. </span><span class="content">Security and Privacy Considerations</span><a class="self-link" href="#security-and-privacy"></a></h2>
    <p>There are no specific security and privacy considerations
 beyond those described in the Generic Sensor API <a data-link-type="biblio" href="#biblio-generic-sensor">[GENERIC-SENSOR]</a>.</p>
    <h2 class="heading settled" data-level="4" id="model"><span class="secno">4. </span><span class="content">Model</span><a class="self-link" href="#model"></a></h2>
-   <p>The accelerometer’s associated <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/sensors/#sensor">Sensor</a></code> subclass is the <code class="idl"><a data-link-type="idl" href="#accelerometer" id="ref-for-accelerometer-1">Accelerometer</a></code> class.</p>
+   <p>The accelerometer’s associated <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/sensors/#sensor">Sensor</a></code> subclass is the <code class="idl"><a data-link-type="idl" href="#accelerometer" id="ref-for-accelerometer-2">Accelerometer</a></code> class.</p>
    <p>Accelerometer has a <a data-link-type="dfn" href="https://w3c.github.io/sensors#default-sensor">default sensor</a>, which is the device’s main accelerometer sensor.</p>
-   <p>A <a data-link-type="dfn" href="https://w3c.github.io/sensors#latest-reading">latest reading</a> per <a data-link-type="dfn" href="https://w3c.github.io/sensors#sensor">sensor</a> of accelerometer type includes three <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry">entries</a> whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-key">keys</a> are "x", "y", "z" and whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-value">values</a> contain device’s <a data-link-type="dfn" href="#acceleration" id="ref-for-acceleration-2">acceleration</a> about the corresponding axes.</p>
+   <p>A <a data-link-type="dfn" href="https://w3c.github.io/sensors#latest-reading">latest reading</a> per <a data-link-type="dfn" href="https://w3c.github.io/sensors#sensor">sensor</a> of accelerometer type includes three <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry">entries</a> whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-key">keys</a> are "x", "y", "z" and whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-value">values</a> contain device’s <a data-link-type="dfn" href="#acceleration" id="ref-for-acceleration-2">acceleration</a> about the corresponding axes. Values can contain also device’s <a data-link-type="dfn" href="#linear-acceleration" id="ref-for-linear-acceleration-1">linear acceleration</a> or <a data-link-type="dfn" href="#gravity" id="ref-for-gravity-1">gravity</a> depending on which object was instantiated.</p>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="acceleration">acceleration</dfn> is the rate of change of velocity of a device with respect to time. Its
-unit is the metre per second squared (m/s^2) <a data-link-type="biblio" href="#biblio-si">[SI]</a>.</p>
+unit is the metre per second squared (m/s<sup>2</sup>) <a data-link-type="biblio" href="#biblio-si">[SI]</a>.</p>
    <p>The frame of reference for the <a data-link-type="dfn" href="#acceleration" id="ref-for-acceleration-3">acceleration</a> measurement must be inertial, such as, the device in free fall would
-provide 0 (m/s^2) <a data-link-type="dfn" href="#acceleration" id="ref-for-acceleration-4">acceleration</a> value for each axis.</p>
+provide 0 (m/s<sup>2</sup>) <a data-link-type="dfn" href="#acceleration" id="ref-for-acceleration-4">acceleration</a> value for each axis.</p>
    <p>The sign of the <a data-link-type="dfn" href="#acceleration" id="ref-for-acceleration-5">acceleration</a> values must be according to the right-hand convention in a <a data-link-type="dfn" href="#local-coordinate-system" id="ref-for-local-coordinate-system-2">local coordinate
 system</a> defined by the device.</p>
-   <p class="note" role="note">Note: The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="local-coordinate-system">local coordinate system</dfn> of a mobile device is usually defined relative to
-the device’s screen when the device in its default orientation (see figure below).</p>
-   <p><img alt="Accelerometer coordinate system." src="accelerometer_coordinate_system.png" srcset="accelerometer_coordinate_system.svg"></p>
+   <p>The <code class="idl"><a data-link-type="idl" href="#linearaccelerationsensor" id="ref-for-linearaccelerationsensor-2">LinearAccelerationSensor</a></code> class is an <code class="idl"><a data-link-type="idl" href="#accelerometer" id="ref-for-accelerometer-3">Accelerometer</a></code>'s subclass. The <code class="idl"><a data-link-type="idl" href="#linearaccelerationsensor" id="ref-for-linearaccelerationsensor-3">LinearAccelerationSensor</a></code>'s <a data-link-type="dfn" href="https://w3c.github.io/sensors#latest-reading">latest reading</a> contains device’s <a data-link-type="dfn" href="#linear-acceleration" id="ref-for-linear-acceleration-2">linear acceleration</a> about the corresponding axes.</p>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="linear-acceleration">linear acceleration</dfn> is an <a data-link-type="dfn" href="#acceleration" id="ref-for-acceleration-6">acceleration</a> that is applied to the device that hosts
-the sensor, without the contribution of a gravity force.</p>
+the sensor, without the contribution of a <a data-link-type="dfn" href="#gravity" id="ref-for-gravity-2">gravity</a> force.</p>
+   <p>The <code class="idl"><a data-link-type="idl" href="#gravitysensor" id="ref-for-gravitysensor-2">GravitySensor</a></code> class is an <code class="idl"><a data-link-type="idl" href="#accelerometer" id="ref-for-accelerometer-4">Accelerometer</a></code>'s subclass. The <code class="idl"><a data-link-type="idl" href="#gravitysensor" id="ref-for-gravitysensor-3">GravitySensor</a></code>'s <a data-link-type="dfn" href="https://w3c.github.io/sensors#latest-reading">latest reading</a> contains device’s <a data-link-type="dfn" href="#acceleration" id="ref-for-acceleration-7">acceleration</a> due to the effect of <a data-link-type="dfn" href="#gravity" id="ref-for-gravity-3">gravity</a> force about the corresponding axes.</p>
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="gravity">gravity</dfn> is a force that attracts an object to the center of the earth, or towards any other physical object having mass.</p>
+   <p class="note" role="note"><span>Note:</span> The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="local-coordinate-system">local coordinate system</dfn> of a mobile device is usually defined relative to
+the device’s screen when the device in its default orientation (see figure below).</p>
+   <p><img alt="Accelerometer coordinate system." src="accelerometer_coordinate_system.png" srcset="accelerometer_coordinate_system.svg" style="display: block;margin: auto;"></p>
    <h2 class="heading settled" data-level="5" id="api"><span class="secno">5. </span><span class="content">API</span><a class="self-link" href="#api"></a></h2>
    <h3 class="heading settled" data-level="5.1" id="accelerometer-interface"><span class="secno">5.1. </span><span class="content">The Accelerometer Interface</span><a class="self-link" href="#accelerometer-interface"></a></h3>
-<pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="Accelerometer" data-dfn-type="constructor" data-export="" data-lt="Accelerometer(accelerometerOptions)|Accelerometer()" id="dom-accelerometer-accelerometer">Constructor<a class="self-link" href="#dom-accelerometer-accelerometer"></a></dfn>(<span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-accelerometeroptions" id="ref-for-dictdef-accelerometeroptions-1">AccelerometerOptions</a> <dfn class="nv idl-code" data-dfn-for="Accelerometer/Accelerometer(accelerometerOptions)" data-dfn-type="argument" data-export="" id="dom-accelerometer-accelerometer-accelerometeroptions-accelerometeroptions">accelerometerOptions<a class="self-link" href="#dom-accelerometer-accelerometer-accelerometeroptions-accelerometeroptions"></a></dfn>)]
+<pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="Accelerometer" data-dfn-type="constructor" data-export="" data-lt="Accelerometer(options)|Accelerometer()" id="dom-accelerometer-accelerometer">Constructor<a class="self-link" href="#dom-accelerometer-accelerometer"></a></dfn>(<span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#dictdef-sensoroptions">SensorOptions</a> <dfn class="nv idl-code" data-dfn-for="Accelerometer/Accelerometer(options)" data-dfn-type="argument" data-export="" id="dom-accelerometer-accelerometer-options-options">options<a class="self-link" href="#dom-accelerometer-accelerometer-options-options"></a></dfn>)]
 <span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="accelerometer">Accelerometer</dfn> : <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#sensor">Sensor</a> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">unrestricted</span> <span class="kt">double</span>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="Accelerometer" data-dfn-type="attribute" data-export="" data-readonly="" data-type="unrestricted double?" id="dom-accelerometer-x">x</dfn>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">unrestricted</span> <span class="kt">double</span>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="Accelerometer" data-dfn-type="attribute" data-export="" data-readonly="" data-type="unrestricted double?" id="dom-accelerometer-y">y</dfn>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">unrestricted</span> <span class="kt">double</span>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="Accelerometer" data-dfn-type="attribute" data-export="" data-readonly="" data-type="unrestricted double?" id="dom-accelerometer-z">z</dfn>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">boolean</span> <dfn class="nv dfn-paneled idl-code" data-dfn-for="Accelerometer" data-dfn-type="attribute" data-export="" data-readonly="" data-type="boolean" id="dom-accelerometer-includesgravity">includesGravity</dfn>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unrestricted-double"><span class="kt">unrestricted</span> <span class="kt">double</span></a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="Accelerometer" data-dfn-type="attribute" data-export="" data-readonly="" data-type="unrestricted double?" id="dom-accelerometer-x">x</dfn>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unrestricted-double"><span class="kt">unrestricted</span> <span class="kt">double</span></a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="Accelerometer" data-dfn-type="attribute" data-export="" data-readonly="" data-type="unrestricted double?" id="dom-accelerometer-y">y</dfn>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unrestricted-double"><span class="kt">unrestricted</span> <span class="kt">double</span></a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="Accelerometer" data-dfn-type="attribute" data-export="" data-readonly="" data-type="unrestricted double?" id="dom-accelerometer-z">z</dfn>;
 };
 </pre>
    <p>To <dfn data-dfn-type="dfn" data-noexport="" id="construct-an-accelerometer-object">Construct an Accelerometer Object<a class="self-link" href="#construct-an-accelerometer-object"></a></dfn> the user agent must invoke
 the <a data-link-type="dfn" href="https://w3c.github.io/sensors#construct-sensor-object">construct a Sensor object</a> abstract operation.</p>
    <h4 class="heading settled" data-level="5.1.1" id="accelerometer-x"><span class="secno">5.1.1. </span><span class="content">Accelerometer.x</span><a class="self-link" href="#accelerometer-x"></a></h4>
-   <p>The <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-accelerometer-x" id="ref-for-dom-accelerometer-x-1">x</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#accelerometer" id="ref-for-accelerometer-2">Accelerometer</a></code> interface represents the <a data-link-type="dfn" href="#acceleration" id="ref-for-acceleration-7">acceleration</a> along X-axis.
+   <p>The <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-accelerometer-x" id="ref-for-dom-accelerometer-x-1">x</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#accelerometer" id="ref-for-accelerometer-5">Accelerometer</a></code> interface represents the <a data-link-type="dfn" href="#acceleration" id="ref-for-acceleration-8">acceleration</a> along x-axis.
 This attribute returns <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-value">value</a> for <a data-link-type="dfn" href="https://w3c.github.io/sensors#latest-reading">latest reading</a>["x"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry">entry</a>.</p>
    <h4 class="heading settled" data-level="5.1.2" id="accelerometer-y"><span class="secno">5.1.2. </span><span class="content">Accelerometer.y</span><a class="self-link" href="#accelerometer-y"></a></h4>
-   <p>The <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-accelerometer-y" id="ref-for-dom-accelerometer-y-1">y</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#accelerometer" id="ref-for-accelerometer-3">Accelerometer</a></code> interface represents the <a data-link-type="dfn" href="#acceleration" id="ref-for-acceleration-8">acceleration</a> along Y-axis.
+   <p>The <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-accelerometer-y" id="ref-for-dom-accelerometer-y-1">y</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#accelerometer" id="ref-for-accelerometer-6">Accelerometer</a></code> interface represents the <a data-link-type="dfn" href="#acceleration" id="ref-for-acceleration-9">acceleration</a> along y-axis.
 This attribute returns <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-value">value</a> for <a data-link-type="dfn" href="https://w3c.github.io/sensors#latest-reading">latest reading</a>["y"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry">entry</a>.</p>
    <h4 class="heading settled" data-level="5.1.3" id="accelerometer-z"><span class="secno">5.1.3. </span><span class="content">Accelerometer.z</span><a class="self-link" href="#accelerometer-z"></a></h4>
-   <p>The <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-accelerometer-z" id="ref-for-dom-accelerometer-z-1">z</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#accelerometer" id="ref-for-accelerometer-4">Accelerometer</a></code> interface represents the <a data-link-type="dfn" href="#acceleration" id="ref-for-acceleration-9">acceleration</a> along Z-axis.
+   <p>The <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-accelerometer-z" id="ref-for-dom-accelerometer-z-1">z</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#accelerometer" id="ref-for-accelerometer-7">Accelerometer</a></code> interface represents the <a data-link-type="dfn" href="#acceleration" id="ref-for-acceleration-10">acceleration</a> along z-axis.
 This attribute returns <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-value">value</a> for <a data-link-type="dfn" href="https://w3c.github.io/sensors#latest-reading">latest reading</a>["z"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry">entry</a>.</p>
-   <h4 class="heading settled" data-level="5.1.4" id="accelerometer-includesGravity"><span class="secno">5.1.4. </span><span class="content">Accelerometer.includesGravity</span><a class="self-link" href="#accelerometer-includesGravity"></a></h4>
-   <p>The <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-accelerometer-includesgravity" id="ref-for-dom-accelerometer-includesgravity-1">includesGravity</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#accelerometer" id="ref-for-accelerometer-5">Accelerometer</a></code> interface represents whether the <a data-link-type="dfn" href="#acceleration" id="ref-for-acceleration-10">acceleration</a> information provided by the sensor includes the effect of the gravity
-force. In case when <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-accelerometer-includesgravity" id="ref-for-dom-accelerometer-includesgravity-2">includesGravity</a></code> equals to false, <code class="idl"><a data-link-type="idl" href="#accelerometer" id="ref-for-accelerometer-6">Accelerometer</a></code> will provide <a data-link-type="dfn" href="#linear-acceleration" id="ref-for-linear-acceleration-1">linear acceleration</a> information.</p>
-   <h3 class="heading settled" data-level="5.2" id="accelerometer-options-dictionary"><span class="secno">5.2. </span><span class="content">The AccelerometerOptions Dictionary</span><a class="self-link" href="#accelerometer-options-dictionary"></a></h3>
-<pre class="idl highlight def"><span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-accelerometeroptions">AccelerometerOptions</dfn> :  <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#dictdef-sensoroptions">SensorOptions</a>  {
-  <span class="kt">boolean</span> <dfn class="nv idl-code" data-default="true" data-dfn-for="AccelerometerOptions" data-dfn-type="dict-member" data-export="" data-type="boolean " id="dom-accelerometeroptions-includegravity">includeGravity<a class="self-link" href="#dom-accelerometeroptions-includegravity"></a></dfn> = <span class="kt">true</span>;
+   <h3 class="heading settled" data-level="5.2" id="linear-accelerometer-interface"><span class="secno">5.2. </span><span class="content">The LinearAccelerationSensor Interface</span><a class="self-link" href="#linear-accelerometer-interface"></a></h3>
+<pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="LinearAccelerationSensor" data-dfn-type="constructor" data-export="" data-lt="LinearAccelerationSensor(options)|LinearAccelerationSensor()" id="dom-linearaccelerationsensor-linearaccelerationsensor">Constructor<a class="self-link" href="#dom-linearaccelerationsensor-linearaccelerationsensor"></a></dfn>(<span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#dictdef-sensoroptions">SensorOptions</a> <dfn class="nv idl-code" data-dfn-for="LinearAccelerationSensor/LinearAccelerationSensor(options)" data-dfn-type="argument" data-export="" id="dom-linearaccelerationsensor-linearaccelerationsensor-options-options">options<a class="self-link" href="#dom-linearaccelerationsensor-linearaccelerationsensor-options-options"></a></dfn>)]
+<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="linearaccelerationsensor">LinearAccelerationSensor</dfn> : <a class="n" data-link-type="idl-name" href="#accelerometer" id="ref-for-accelerometer-8">Accelerometer</a> {
 };
 </pre>
-   <p>By default, accelerometer sensor provides <a data-link-type="dfn" href="#acceleration" id="ref-for-acceleration-11">acceleration</a> information including the effect of the gravity force.
-In cases when <a data-link-type="dfn" href="#linear-acceleration" id="ref-for-linear-acceleration-2">linear acceleration</a> information is required, <code class="idl"><a data-link-type="idl" href="#dictdef-accelerometeroptions" id="ref-for-dictdef-accelerometeroptions-2">AccelerometerOptions</a></code> dictionary
-must include an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry">entry</a> whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-key">key</a> is "includeGravity" and whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-value">value</a> is false.</p>
+   <p>To <dfn data-dfn-type="dfn" data-noexport="" id="construct-a-linearaccelerationsensor-object">Construct a LinearAccelerationSensor Object<a class="self-link" href="#construct-a-linearaccelerationsensor-object"></a></dfn> the user agent must invoke
+the <a data-link-type="dfn" href="https://w3c.github.io/sensors#construct-sensor-object">construct a Sensor object</a> abstract operation.</p>
+   <h4 class="heading settled" data-level="5.2.1" id="linearaccelerationsensor-x"><span class="secno">5.2.1. </span><span class="content">LinearAccelerationSensor.x</span><a class="self-link" href="#linearaccelerationsensor-x"></a></h4>
+   <p>The <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-accelerometer-x" id="ref-for-dom-accelerometer-x-2">x</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#linearaccelerationsensor" id="ref-for-linearaccelerationsensor-4">LinearAccelerationSensor</a></code> interface represents the <a data-link-type="dfn" href="#linear-acceleration" id="ref-for-linear-acceleration-3">linear acceleration</a> along x-axis.
+This attribute returns <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-value">value</a> for <a data-link-type="dfn" href="https://w3c.github.io/sensors#latest-reading">latest reading</a>["x"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry">entry</a>.</p>
+   <h4 class="heading settled" data-level="5.2.2" id="linearaccelerationsensor-y"><span class="secno">5.2.2. </span><span class="content">LinearAccelerationSensor.y</span><a class="self-link" href="#linearaccelerationsensor-y"></a></h4>
+   <p>The <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-accelerometer-y" id="ref-for-dom-accelerometer-y-2">y</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#linearaccelerationsensor" id="ref-for-linearaccelerationsensor-5">LinearAccelerationSensor</a></code> interface represents the <a data-link-type="dfn" href="#linear-acceleration" id="ref-for-linear-acceleration-4">linear acceleration</a> along y-axis.
+This attribute returns <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-value">value</a> for <a data-link-type="dfn" href="https://w3c.github.io/sensors#latest-reading">latest reading</a>["y"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry">entry</a>.</p>
+   <h4 class="heading settled" data-level="5.2.3" id="linearaccelerationsensor-z"><span class="secno">5.2.3. </span><span class="content">LinearAccelerationSensor.z</span><a class="self-link" href="#linearaccelerationsensor-z"></a></h4>
+   <p>The <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-accelerometer-z" id="ref-for-dom-accelerometer-z-2">z</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#linearaccelerationsensor" id="ref-for-linearaccelerationsensor-6">LinearAccelerationSensor</a></code> interface represents the <a data-link-type="dfn" href="#linear-acceleration" id="ref-for-linear-acceleration-5">linear acceleration</a> along z-axis.
+This attribute returns <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-value">value</a> for <a data-link-type="dfn" href="https://w3c.github.io/sensors#latest-reading">latest reading</a>["z"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry">entry</a>.</p>
+   <h3 class="heading settled" data-level="5.3" id="gravity-sensor-interface"><span class="secno">5.3. </span><span class="content">The GravitySensor Interface</span><a class="self-link" href="#gravity-sensor-interface"></a></h3>
+<pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="GravitySensor" data-dfn-type="constructor" data-export="" data-lt="GravitySensor(options)|GravitySensor()" id="dom-gravitysensor-gravitysensor">Constructor<a class="self-link" href="#dom-gravitysensor-gravitysensor"></a></dfn>(<span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#dictdef-sensoroptions">SensorOptions</a> <dfn class="nv idl-code" data-dfn-for="GravitySensor/GravitySensor(options)" data-dfn-type="argument" data-export="" id="dom-gravitysensor-gravitysensor-options-options">options<a class="self-link" href="#dom-gravitysensor-gravitysensor-options-options"></a></dfn>)]
+<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="gravitysensor">GravitySensor</dfn> : <a class="n" data-link-type="idl-name" href="#accelerometer" id="ref-for-accelerometer-9">Accelerometer</a> {
+};
+</pre>
+   <p>To <dfn data-dfn-type="dfn" data-noexport="" id="construct-an-gravitysensor-object">Construct an GravitySensor Object<a class="self-link" href="#construct-an-gravitysensor-object"></a></dfn> the user agent must invoke
+the <a data-link-type="dfn" href="https://w3c.github.io/sensors#construct-sensor-object">construct a Sensor object</a> abstract operation.</p>
+   <h4 class="heading settled" data-level="5.3.1" id="gravitysensor-x"><span class="secno">5.3.1. </span><span class="content">GravitySensor.x</span><a class="self-link" href="#gravitysensor-x"></a></h4>
+   <p>The <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-accelerometer-x" id="ref-for-dom-accelerometer-x-3">x</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#gravitysensor" id="ref-for-gravitysensor-4">GravitySensor</a></code> interface represents the effect of <a data-link-type="dfn" href="#acceleration" id="ref-for-acceleration-11">acceleration</a> along x-axis due to <a data-link-type="dfn" href="#gravity" id="ref-for-gravity-4">gravity</a>.
+This attribute returns <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-value">value</a> for <a data-link-type="dfn" href="https://w3c.github.io/sensors#latest-reading">latest reading</a>["x"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry">entry</a>.</p>
+   <h4 class="heading settled" data-level="5.3.2" id="gravitysensor-y"><span class="secno">5.3.2. </span><span class="content">GravitySensor.y</span><a class="self-link" href="#gravitysensor-y"></a></h4>
+   <p>The <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-accelerometer-y" id="ref-for-dom-accelerometer-y-3">y</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#gravitysensor" id="ref-for-gravitysensor-5">GravitySensor</a></code> interface represents the effect of <a data-link-type="dfn" href="#acceleration" id="ref-for-acceleration-12">acceleration</a> along y-axis due to <a data-link-type="dfn" href="#gravity" id="ref-for-gravity-5">gravity</a>.
+This attribute returns <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-value">value</a> for <a data-link-type="dfn" href="https://w3c.github.io/sensors#latest-reading">latest reading</a>["y"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry">entry</a>.</p>
+   <h4 class="heading settled" data-level="5.3.3" id="gravitysensor-z"><span class="secno">5.3.3. </span><span class="content">GravitySensor.z</span><a class="self-link" href="#gravitysensor-z"></a></h4>
+   <p>The <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-accelerometer-z" id="ref-for-dom-accelerometer-z-3">z</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#gravitysensor" id="ref-for-gravitysensor-6">GravitySensor</a></code> interface represents the effect of <a data-link-type="dfn" href="#acceleration" id="ref-for-acceleration-13">acceleration</a> along z-axis due to <a data-link-type="dfn" href="#gravity" id="ref-for-gravity-6">gravity</a>.
+This attribute returns <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-value">value</a> for <a data-link-type="dfn" href="https://w3c.github.io/sensors#latest-reading">latest reading</a>["z"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry">entry</a>.</p>
    <h2 class="heading settled" data-level="6" id="acknowledgements"><span class="secno">6. </span><span class="content">Acknowledgements</span><a class="self-link" href="#acknowledgements"></a></h2>
    <p>Tobie Langel for the work on Generic Sensor API.</p>
    <h2 class="heading settled" data-level="7" id="conformance"><span class="secno">7. </span><span class="content">Conformance</span><a class="self-link" href="#conformance"></a></h2>
@@ -1613,13 +1650,19 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
    <li><a href="#acceleration">acceleration</a><span>, in §4</span>
    <li><a href="#accelerometer">Accelerometer</a><span>, in §5.1</span>
    <li><a href="#dom-accelerometer-accelerometer">Accelerometer()</a><span>, in §5.1</span>
-   <li><a href="#dom-accelerometer-accelerometer">Accelerometer(accelerometerOptions)</a><span>, in §5.1</span>
-   <li><a href="#dictdef-accelerometeroptions">AccelerometerOptions</a><span>, in §5.2</span>
+   <li><a href="#dom-accelerometer-accelerometer">Accelerometer(options)</a><span>, in §5.1</span>
    <li><a href="#conformant-user-agent">conformant user agent</a><span>, in §7</span>
+   <li><a href="#construct-a-linearaccelerationsensor-object">Construct a LinearAccelerationSensor Object</a><span>, in §5.2</span>
    <li><a href="#construct-an-accelerometer-object">Construct an Accelerometer Object</a><span>, in §5.1</span>
-   <li><a href="#dom-accelerometeroptions-includegravity">includeGravity</a><span>, in §5.2</span>
-   <li><a href="#dom-accelerometer-includesgravity">includesGravity</a><span>, in §5.1</span>
+   <li><a href="#construct-an-gravitysensor-object">Construct an GravitySensor Object</a><span>, in §5.3</span>
+   <li><a href="#gravity">gravity</a><span>, in §4</span>
+   <li><a href="#dom-gravitysensor-gravitysensor">GravitySensor()</a><span>, in §5.3</span>
+   <li><a href="#gravitysensor">GravitySensor</a><span>, in §5.3</span>
+   <li><a href="#dom-gravitysensor-gravitysensor">GravitySensor(options)</a><span>, in §5.3</span>
    <li><a href="#linear-acceleration">linear acceleration</a><span>, in §4</span>
+   <li><a href="#dom-linearaccelerationsensor-linearaccelerationsensor">LinearAccelerationSensor()</a><span>, in §5.2</span>
+   <li><a href="#linearaccelerationsensor">LinearAccelerationSensor</a><span>, in §5.2</span>
+   <li><a href="#dom-linearaccelerationsensor-linearaccelerationsensor">LinearAccelerationSensor(options)</a><span>, in §5.2</span>
    <li><a href="#local-coordinate-system">local coordinate system</a><span>, in §4</span>
    <li><a href="#dom-accelerometer-x">x</a><span>, in §5.1</span>
    <li><a href="#dom-accelerometer-y">y</a><span>, in §5.1</span>
@@ -1648,18 +1691,23 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
      <li><a href="https://infra.spec.whatwg.org/#map-key">key</a>
      <li><a href="https://infra.spec.whatwg.org/#map-value">value</a>
     </ul>
+   <li>
+    <a data-link-type="biblio">[WEBIDL]</a> defines the following terms:
+    <ul>
+     <li><a href="https://heycam.github.io/webidl/#idl-unrestricted-double">unrestricted double</a>
+    </ul>
   </ul>
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
   <h3 class="no-num no-ref heading settled" id="normative"><span class="content">Normative References</span><a class="self-link" href="#normative"></a></h3>
   <dl>
    <dt id="biblio-generic-sensor">[GENERIC-SENSOR]
-   <dd>Tobie Langel; Rick Waldron. <a href="https://w3c.github.io/sensors/">Generic Sensor API</a>. 30 August 2016. WD. URL: <a href="https://w3c.github.io/sensors/">https://w3c.github.io/sensors/</a>
+   <dd>Tobie Langel; Rick Waldron. <a href="https://www.w3.org/TR/generic-sensor/">Generic Sensor API</a>. URL: <a href="https://www.w3.org/TR/generic-sensor/">https://www.w3.org/TR/generic-sensor/</a>
    <dt id="biblio-infra">[INFRA]
    <dd>Anne van Kesteren; Domenic Denicola. <a href="https://infra.spec.whatwg.org/">Infra Standard</a>. Living Standard. URL: <a href="https://infra.spec.whatwg.org/">https://infra.spec.whatwg.org/</a>
    <dt id="biblio-rfc2119">[RFC2119]
    <dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a>
    <dt id="biblio-webidl">[WEBIDL]
-   <dd>Cameron McCormack; Boris Zbarsky; Tobie Langel. <a href="https://heycam.github.io/webidl/">Web IDL</a>. 15 December 2016. WD. URL: <a href="https://heycam.github.io/webidl/">https://heycam.github.io/webidl/</a>
+   <dd>Cameron McCormack; Boris Zbarsky; Tobie Langel. <a href="https://www.w3.org/TR/WebIDL-1/">Web IDL</a>. URL: <a href="https://www.w3.org/TR/WebIDL-1/">https://www.w3.org/TR/WebIDL-1/</a>
   </dl>
   <h3 class="no-num no-ref heading settled" id="informative"><span class="content">Informative References</span><a class="self-link" href="#informative"></a></h3>
   <dl>
@@ -1667,16 +1715,19 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
    <dd><a href="http://www.bipm.org/en/publications/si-brochure/">SI Brochure: The International System of Units (SI), 8th edition</a>. 2014. URL: <a href="http://www.bipm.org/en/publications/si-brochure/">http://www.bipm.org/en/publications/si-brochure/</a>
   </dl>
   <h2 class="no-num no-ref heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>
-<pre class="idl def">[<a class="nv" href="#dom-accelerometer-accelerometer">Constructor</a>(<span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-accelerometeroptions">AccelerometerOptions</a> <a class="nv" href="#dom-accelerometer-accelerometer-accelerometeroptions-accelerometeroptions">accelerometerOptions</a>)]
+<pre class="idl def">[<a class="nv" href="#dom-accelerometer-accelerometer">Constructor</a>(<span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#dictdef-sensoroptions">SensorOptions</a> <a class="nv" href="#dom-accelerometer-accelerometer-options-options">options</a>)]
 <span class="kt">interface</span> <a class="nv" href="#accelerometer">Accelerometer</a> : <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#sensor">Sensor</a> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">unrestricted</span> <span class="kt">double</span>? <a class="nv" data-readonly="" data-type="unrestricted double?" href="#dom-accelerometer-x">x</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">unrestricted</span> <span class="kt">double</span>? <a class="nv" data-readonly="" data-type="unrestricted double?" href="#dom-accelerometer-y">y</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">unrestricted</span> <span class="kt">double</span>? <a class="nv" data-readonly="" data-type="unrestricted double?" href="#dom-accelerometer-z">z</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">boolean</span> <a class="nv" data-readonly="" data-type="boolean" href="#dom-accelerometer-includesgravity">includesGravity</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unrestricted-double"><span class="kt">unrestricted</span> <span class="kt">double</span></a>? <a class="nv" data-readonly="" data-type="unrestricted double?" href="#dom-accelerometer-x">x</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unrestricted-double"><span class="kt">unrestricted</span> <span class="kt">double</span></a>? <a class="nv" data-readonly="" data-type="unrestricted double?" href="#dom-accelerometer-y">y</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unrestricted-double"><span class="kt">unrestricted</span> <span class="kt">double</span></a>? <a class="nv" data-readonly="" data-type="unrestricted double?" href="#dom-accelerometer-z">z</a>;
 };
 
-<span class="kt">dictionary</span> <a class="nv" href="#dictdef-accelerometeroptions">AccelerometerOptions</a> :  <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#dictdef-sensoroptions">SensorOptions</a>  {
-  <span class="kt">boolean</span> <a class="nv" data-default="true" data-type="boolean " href="#dom-accelerometeroptions-includegravity">includeGravity</a> = <span class="kt">true</span>;
+[<a class="nv" href="#dom-linearaccelerationsensor-linearaccelerationsensor">Constructor</a>(<span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#dictdef-sensoroptions">SensorOptions</a> <a class="nv" href="#dom-linearaccelerationsensor-linearaccelerationsensor-options-options">options</a>)]
+<span class="kt">interface</span> <a class="nv" href="#linearaccelerationsensor">LinearAccelerationSensor</a> : <a class="n" data-link-type="idl-name" href="#accelerometer">Accelerometer</a> {
+};
+
+[<a class="nv" href="#dom-gravitysensor-gravitysensor">Constructor</a>(<span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#dictdef-sensoroptions">SensorOptions</a> <a class="nv" href="#dom-gravitysensor-gravitysensor-options-options">options</a>)]
+<span class="kt">interface</span> <a class="nv" href="#gravitysensor">GravitySensor</a> : <a class="n" data-link-type="idl-name" href="#accelerometer">Accelerometer</a> {
 };
 
 </pre>
@@ -1684,12 +1735,31 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
    <b><a href="#acceleration">#acceleration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-acceleration-1">1. Introduction</a>
-    <li><a href="#ref-for-acceleration-2">4. Model</a> <a href="#ref-for-acceleration-3">(2)</a> <a href="#ref-for-acceleration-4">(3)</a> <a href="#ref-for-acceleration-5">(4)</a> <a href="#ref-for-acceleration-6">(5)</a>
-    <li><a href="#ref-for-acceleration-7">5.1.1. Accelerometer.x</a>
-    <li><a href="#ref-for-acceleration-8">5.1.2. Accelerometer.y</a>
-    <li><a href="#ref-for-acceleration-9">5.1.3. Accelerometer.z</a>
-    <li><a href="#ref-for-acceleration-10">5.1.4. Accelerometer.includesGravity</a>
-    <li><a href="#ref-for-acceleration-11">5.2. The AccelerometerOptions Dictionary</a>
+    <li><a href="#ref-for-acceleration-2">4. Model</a> <a href="#ref-for-acceleration-3">(2)</a> <a href="#ref-for-acceleration-4">(3)</a> <a href="#ref-for-acceleration-5">(4)</a> <a href="#ref-for-acceleration-6">(5)</a> <a href="#ref-for-acceleration-7">(6)</a>
+    <li><a href="#ref-for-acceleration-8">5.1.1. Accelerometer.x</a>
+    <li><a href="#ref-for-acceleration-9">5.1.2. Accelerometer.y</a>
+    <li><a href="#ref-for-acceleration-10">5.1.3. Accelerometer.z</a>
+    <li><a href="#ref-for-acceleration-11">5.3.1. GravitySensor.x</a>
+    <li><a href="#ref-for-acceleration-12">5.3.2. GravitySensor.y</a>
+    <li><a href="#ref-for-acceleration-13">5.3.3. GravitySensor.z</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="linear-acceleration">
+   <b><a href="#linear-acceleration">#linear-acceleration</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-linear-acceleration-1">4. Model</a> <a href="#ref-for-linear-acceleration-2">(2)</a>
+    <li><a href="#ref-for-linear-acceleration-3">5.2.1. LinearAccelerationSensor.x</a>
+    <li><a href="#ref-for-linear-acceleration-4">5.2.2. LinearAccelerationSensor.y</a>
+    <li><a href="#ref-for-linear-acceleration-5">5.2.3. LinearAccelerationSensor.z</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="gravity">
+   <b><a href="#gravity">#gravity</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-gravity-1">4. Model</a> <a href="#ref-for-gravity-2">(2)</a> <a href="#ref-for-gravity-3">(3)</a>
+    <li><a href="#ref-for-gravity-4">5.3.1. GravitySensor.x</a>
+    <li><a href="#ref-for-gravity-5">5.3.2. GravitySensor.y</a>
+    <li><a href="#ref-for-gravity-6">5.3.3. GravitySensor.z</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="local-coordinate-system">
@@ -1699,52 +1769,60 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
     <li><a href="#ref-for-local-coordinate-system-2">4. Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="linear-acceleration">
-   <b><a href="#linear-acceleration">#linear-acceleration</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-linear-acceleration-1">5.1.4. Accelerometer.includesGravity</a>
-    <li><a href="#ref-for-linear-acceleration-2">5.2. The AccelerometerOptions Dictionary</a>
-   </ul>
-  </aside>
   <aside class="dfn-panel" data-for="accelerometer">
    <b><a href="#accelerometer">#accelerometer</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-accelerometer-1">4. Model</a>
-    <li><a href="#ref-for-accelerometer-2">5.1.1. Accelerometer.x</a>
-    <li><a href="#ref-for-accelerometer-3">5.1.2. Accelerometer.y</a>
-    <li><a href="#ref-for-accelerometer-4">5.1.3. Accelerometer.z</a>
-    <li><a href="#ref-for-accelerometer-5">5.1.4. Accelerometer.includesGravity</a> <a href="#ref-for-accelerometer-6">(2)</a>
+    <li><a href="#ref-for-accelerometer-1">1. Introduction</a>
+    <li><a href="#ref-for-accelerometer-2">4. Model</a> <a href="#ref-for-accelerometer-3">(2)</a> <a href="#ref-for-accelerometer-4">(3)</a>
+    <li><a href="#ref-for-accelerometer-5">5.1.1. Accelerometer.x</a>
+    <li><a href="#ref-for-accelerometer-6">5.1.2. Accelerometer.y</a>
+    <li><a href="#ref-for-accelerometer-7">5.1.3. Accelerometer.z</a>
+    <li><a href="#ref-for-accelerometer-8">5.2. The LinearAccelerationSensor Interface</a>
+    <li><a href="#ref-for-accelerometer-9">5.3. The GravitySensor Interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-accelerometer-x">
    <b><a href="#dom-accelerometer-x">#dom-accelerometer-x</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-accelerometer-x-1">5.1.1. Accelerometer.x</a>
+    <li><a href="#ref-for-dom-accelerometer-x-2">5.2.1. LinearAccelerationSensor.x</a>
+    <li><a href="#ref-for-dom-accelerometer-x-3">5.3.1. GravitySensor.x</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-accelerometer-y">
    <b><a href="#dom-accelerometer-y">#dom-accelerometer-y</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-accelerometer-y-1">5.1.2. Accelerometer.y</a>
+    <li><a href="#ref-for-dom-accelerometer-y-2">5.2.2. LinearAccelerationSensor.y</a>
+    <li><a href="#ref-for-dom-accelerometer-y-3">5.3.2. GravitySensor.y</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-accelerometer-z">
    <b><a href="#dom-accelerometer-z">#dom-accelerometer-z</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-accelerometer-z-1">5.1.3. Accelerometer.z</a>
+    <li><a href="#ref-for-dom-accelerometer-z-2">5.2.3. LinearAccelerationSensor.z</a>
+    <li><a href="#ref-for-dom-accelerometer-z-3">5.3.3. GravitySensor.z</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-accelerometer-includesgravity">
-   <b><a href="#dom-accelerometer-includesgravity">#dom-accelerometer-includesgravity</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="linearaccelerationsensor">
+   <b><a href="#linearaccelerationsensor">#linearaccelerationsensor</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-accelerometer-includesgravity-1">5.1.4. Accelerometer.includesGravity</a> <a href="#ref-for-dom-accelerometer-includesgravity-2">(2)</a>
+    <li><a href="#ref-for-linearaccelerationsensor-1">1. Introduction</a>
+    <li><a href="#ref-for-linearaccelerationsensor-2">4. Model</a> <a href="#ref-for-linearaccelerationsensor-3">(2)</a>
+    <li><a href="#ref-for-linearaccelerationsensor-4">5.2.1. LinearAccelerationSensor.x</a>
+    <li><a href="#ref-for-linearaccelerationsensor-5">5.2.2. LinearAccelerationSensor.y</a>
+    <li><a href="#ref-for-linearaccelerationsensor-6">5.2.3. LinearAccelerationSensor.z</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-accelerometeroptions">
-   <b><a href="#dictdef-accelerometeroptions">#dictdef-accelerometeroptions</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="gravitysensor">
+   <b><a href="#gravitysensor">#gravitysensor</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dictdef-accelerometeroptions-1">5.1. The Accelerometer Interface</a>
-    <li><a href="#ref-for-dictdef-accelerometeroptions-2">5.2. The AccelerometerOptions Dictionary</a>
+    <li><a href="#ref-for-gravitysensor-1">1. Introduction</a>
+    <li><a href="#ref-for-gravitysensor-2">4. Model</a> <a href="#ref-for-gravitysensor-3">(2)</a>
+    <li><a href="#ref-for-gravitysensor-4">5.3.1. GravitySensor.x</a>
+    <li><a href="#ref-for-gravitysensor-5">5.3.2. GravitySensor.y</a>
+    <li><a href="#ref-for-gravitysensor-6">5.3.3. GravitySensor.z</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */


### PR DESCRIPTION
This PR splits Accelerometer interface into 3 concrete sensors
 - Accelerometer that provides acceleration
 - LinearAccelerationSensor that provides linear acceleration
 - GravitySensor that provides acceleration due to effect of gravity

Fix #3
Fix #13


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/alexshalamov/accelerometer/gh-pages.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/accelerometer/6299247...alexshalamov:c335898.html)