### PR TITLE
Add permission descriptor for Accelerometer API

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -69,7 +69,9 @@ Model {#model}
 
 The accelerometer's associated {{Sensor}} subclass is the {{Accelerometer}} class.
 
-Accelerometer has a [=default sensor=], which is the device's main accelerometer sensor.
+The Accelerometer has a [=default sensor=], which is the device's main accelerometer sensor.
+
+The Accelerometer has an associated {{PermissionName}} which is <a for="PermissionName" enum-value>"accelerometer"</a>.
 
 A [=latest reading=] per [=sensor=] of accelerometer type includes three [=map/entries=]
 whose [=map/keys=] are "x", "y", "z" and whose [=map/values=] contain device's [=acceleration=]

--- a/index.html
+++ b/index.html
@@ -1183,7 +1183,8 @@ Possible extra rowspan handling
       background-attachment: fixed;
     }
   </style>
-  <meta content="Bikeshed version fa6d32dea6b39d19cbb9dd6d5e69f189e8bdd53f" name="generator">
+  <meta content="Bikeshed version b734e371910e25ac23b774dca3dea5cfc7b7fc0b" name="generator">
+  <link href="https://www.w3.org/TR/accelerometer/" rel="canonical">
 <style>/* style-md-lists */
 
             /* This is a weird hack for me not yet following the commonmark spec
@@ -1430,7 +1431,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Accelerometer</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-03-16">16 March 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-03-31">31 March 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1558,7 +1559,8 @@ sensor<span class="p">.</span>onerror <span class="o">=</span> event <span class
 beyond those described in the Generic Sensor API <a data-link-type="biblio" href="#biblio-generic-sensor">[GENERIC-SENSOR]</a>.</p>
    <h2 class="heading settled" data-level="4" id="model"><span class="secno">4. </span><span class="content">Model</span><a class="self-link" href="#model"></a></h2>
    <p>The accelerometer’s associated <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/sensors/#sensor">Sensor</a></code> subclass is the <code class="idl"><a data-link-type="idl" href="#accelerometer" id="ref-for-accelerometer-2">Accelerometer</a></code> class.</p>
-   <p>Accelerometer has a <a data-link-type="dfn" href="https://w3c.github.io/sensors#default-sensor">default sensor</a>, which is the device’s main accelerometer sensor.</p>
+   <p>The Accelerometer has a <a data-link-type="dfn" href="https://w3c.github.io/sensors#default-sensor">default sensor</a>, which is the device’s main accelerometer sensor.</p>
+   <p>The Accelerometer has an associated <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname">PermissionName</a></code> which is <a class="idl-code" data-link-type="enum-value">"accelerometer"</a>.</p>
    <p>A <a data-link-type="dfn" href="https://w3c.github.io/sensors#latest-reading">latest reading</a> per <a data-link-type="dfn" href="https://w3c.github.io/sensors#sensor">sensor</a> of accelerometer type includes three <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry">entries</a> whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-key">keys</a> are "x", "y", "z" and whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-value">values</a> contain device’s <a data-link-type="dfn" href="#acceleration" id="ref-for-acceleration-2">acceleration</a> about the corresponding axes. Values can contain also device’s <a data-link-type="dfn" href="#linear-acceleration" id="ref-for-linear-acceleration-1">linear acceleration</a> or <a data-link-type="dfn" href="#gravity" id="ref-for-gravity-1">gravity</a> depending on which object was instantiated.</p>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="acceleration">acceleration</dfn> is the rate of change of velocity of a device with respect to time. Its
 unit is the metre per second squared (m/s<sup>2</sup>) <a data-link-type="biblio" href="#biblio-si">[SI]</a>.</p>
@@ -1692,6 +1694,11 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
      <li><a href="https://infra.spec.whatwg.org/#map-value">value</a>
     </ul>
    <li>
+    <a data-link-type="biblio">[permissions]</a> defines the following terms:
+    <ul>
+     <li><a href="https://w3c.github.io/permissions/#enumdef-permissionname">PermissionName</a>
+    </ul>
+   <li>
     <a data-link-type="biblio">[WEBIDL]</a> defines the following terms:
     <ul>
      <li><a href="https://heycam.github.io/webidl/#idl-unrestricted-double">unrestricted double</a>
@@ -1704,6 +1711,8 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
    <dd>Tobie Langel; Rick Waldron. <a href="https://www.w3.org/TR/generic-sensor/">Generic Sensor API</a>. URL: <a href="https://www.w3.org/TR/generic-sensor/">https://www.w3.org/TR/generic-sensor/</a>
    <dt id="biblio-infra">[INFRA]
    <dd>Anne van Kesteren; Domenic Denicola. <a href="https://infra.spec.whatwg.org/">Infra Standard</a>. Living Standard. URL: <a href="https://infra.spec.whatwg.org/">https://infra.spec.whatwg.org/</a>
+   <dt id="biblio-permissions">[PERMISSIONS]
+   <dd>Mounir Lamouri; Marcos Caceres. <a href="https://www.w3.org/TR/permissions/">The Permissions API</a>. URL: <a href="https://www.w3.org/TR/permissions/">https://www.w3.org/TR/permissions/</a>
    <dt id="biblio-rfc2119">[RFC2119]
    <dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a>
    <dt id="biblio-webidl">[WEBIDL]


### PR DESCRIPTION
Fixes #4


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/alexshalamov/accelerometer/gh-pages.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/accelerometer/744d756...alexshalamov:018a883.html)