### PR TITLE
Ask for tests for normative changes in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,3 +20,12 @@ If you added a contributor by mistake, you can remove them in a comment with:
 
 If you are making a pull request on behalf of someone else but you had no part in designing the
 feature, you can remove yourself with the above syntax.
+
+# Tests
+
+For normative changes, a corresponding
+[web-platform-tests](https://github.com/w3c/web-platform-tests) PR is highly appreciated. Typically,
+both PRs will be merged at the same time. Note that a test change that contradicts the spec should
+not be merged before the corresponding spec change. If testing is not practical, please explain why
+and if appropriate [file a web-platform-tests issue](https://github.com/w3c/web-platform-tests/issues/new)
+to follow up later. Add the `type:untestable` or `type:missing-coverage` label as appropriate.


### PR DESCRIPTION
See https://github.com/foolip/testing-in-standards/blob/master/policy.md
for context. This phrasing matches that used for many other specs'
CONTRIBUTING.md files.

This spec seems to be fairly stable, and an implementation is shipping in
Chrome as part of its Origin Trial process since Chrome 63.

See also: w3c/dap-charter#48