### PR TITLE
Fix link to 'local coordinate system'

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -33,6 +33,7 @@ urlPrefix: https://w3c.github.io/sensors; spec: GENERIC-SENSOR
     text: default sensor
     text: construct a sensor object; url: construct-sensor-object
     text: sensor type
+    text: local coordinate system
 urlPrefix: https://w3c.github.io/screen-orientation; spec: SCREEN-ORIENTATION
   type: dfn
     text: current orientation type;  url: dfn-current-orientation-type

--- a/index.html
+++ b/index.html
@@ -1550,7 +1550,7 @@ of a device that hosts the sensor.</p>
   <main>
    <h2 class="heading settled" data-level="1" id="intro"><span class="secno">1. </span><span class="content">Introduction</span><a class="self-link" href="#intro"></a></h2>
    <p>The <code class="idl"><a data-link-type="idl" href="#accelerometer" id="ref-for-accelerometer①">Accelerometer</a></code>, <code class="idl"><a data-link-type="idl" href="#linearaccelerationsensor" id="ref-for-linearaccelerationsensor①">LinearAccelerationSensor</a></code> and <code class="idl"><a data-link-type="idl" href="#gravitysensor" id="ref-for-gravitysensor①">GravitySensor</a></code> APIs extends the Generic Sensor API <a data-link-type="biblio" href="#biblio-generic-sensor">[GENERIC-SENSOR]</a> interface to provide information about <a data-link-type="dfn" href="#acceleration" id="ref-for-acceleration①">acceleration</a> applied to device’s
-X, Y and Z axis in <a data-link-type="dfn" href="https://drafts.csswg.org/css-transforms-1/#local-coordinate-system" id="ref-for-local-coordinate-system">local coordinate system</a> defined by device.</p>
+X, Y and Z axis in <a data-link-type="dfn" href="https://w3c.github.io/sensors#local-coordinate-system" id="ref-for-local-coordinate-system">local coordinate system</a> defined by device.</p>
    <h2 class="heading settled" data-level="2" id="examples"><span class="secno">2. </span><span class="content">Examples</span><a class="self-link" href="#examples"></a></h2>
    <div class="example" id="example-a07da87c">
     <a class="self-link" href="#example-a07da87c"></a> 
@@ -1580,7 +1580,7 @@ beyond those described in the Generic Sensor API <a data-link-type="biblio" href
 unit is the metre per second squared (m/s<sup>2</sup>) <a data-link-type="biblio" href="#biblio-si">[SI]</a>.</p>
    <p>The frame of reference for the <a data-link-type="dfn" href="#acceleration" id="ref-for-acceleration③">acceleration</a> measurement must be inertial, such as, the device in free fall would
 provide 0 (m/s<sup>2</sup>) <a data-link-type="dfn" href="#acceleration" id="ref-for-acceleration④">acceleration</a> value for each axis.</p>
-   <p>The sign of the <a data-link-type="dfn" href="#acceleration" id="ref-for-acceleration⑤">acceleration</a> values must be according to the right-hand convention in a <a data-link-type="dfn" href="https://drafts.csswg.org/css-transforms-1/#local-coordinate-system" id="ref-for-local-coordinate-system①">local coordinate
+   <p>The sign of the <a data-link-type="dfn" href="#acceleration" id="ref-for-acceleration⑤">acceleration</a> values must be according to the right-hand convention in a <a data-link-type="dfn" href="https://w3c.github.io/sensors#local-coordinate-system" id="ref-for-local-coordinate-system①">local coordinate
 system</a> (see figure below).</p>
    <p><img alt="Accelerometer coordinate system." src="images/accelerometer_coordinate_system.png" srcset="images/accelerometer_coordinate_system.svg" style="display: block;margin: auto;"></p>
    <p>The <code class="idl"><a data-link-type="idl" href="#linearaccelerationsensor" id="ref-for-linearaccelerationsensor②">LinearAccelerationSensor</a></code> class is an <code class="idl"><a data-link-type="idl" href="#accelerometer" id="ref-for-accelerometer③">Accelerometer</a></code>'s subclass. The <code class="idl"><a data-link-type="idl" href="#linearaccelerationsensor" id="ref-for-linearaccelerationsensor③">LinearAccelerationSensor</a></code>'s <a data-link-type="dfn" href="https://w3c.github.io/sensors#latest-reading" id="ref-for-latest-reading①">latest reading</a> contains device’s <a data-link-type="dfn" href="#linear-acceleration" id="ref-for-linear-acceleration①">linear acceleration</a> about the corresponding axes.</p>
@@ -1590,7 +1590,7 @@ the sensor, without the contribution of a <a data-link-type="dfn" href="#gravity
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="gravity">gravity</dfn> is a force that attracts an object to the center of the earth, or towards any other physical object having mass.</p>
    <h3 class="heading settled" data-level="5.1" id="reference-frame"><span class="secno">5.1. </span><span class="content">Reference Frame</span><a class="self-link" href="#reference-frame"></a></h3>
    <p>The reference frame for the sensor classes defined in this specification,
-is expressed in a <a data-link-type="dfn" href="https://drafts.csswg.org/css-transforms-1/#local-coordinate-system" id="ref-for-local-coordinate-system②">local coordinate system</a>, which can be defined as
+is expressed in a <a data-link-type="dfn" href="https://w3c.github.io/sensors#local-coordinate-system" id="ref-for-local-coordinate-system②">local coordinate system</a>, which can be defined as
 either the <a data-link-type="dfn" href="#device-coordinate-system" id="ref-for-device-coordinate-system">device coordinate system</a>, or the <a data-link-type="dfn" href="#screen-coordinate-system" id="ref-for-screen-coordinate-system">screen coordinate system</a>.</p>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="device-coordinate-system">device coordinate system</dfn> is defined as a three dimensional
 Cartesian coordinate system (x, y, z), which is bound to the physical device.
@@ -1634,10 +1634,10 @@ i.e. it will swap X and Y axes in relation to the device if the <a data-link-typ
       <p>If <var>options</var>.<code class="idl"><a class="idl-code" data-link-type="dict-member" href="#dom-spatialsensoroptions-referenceframe" id="ref-for-dom-spatialsensoroptions-referenceframe">referenceFrame</a></code> is "screen", then:</p>
       <ol>
        <li data-md="">
-        <p>Define <a data-link-type="dfn" href="https://drafts.csswg.org/css-transforms-1/#local-coordinate-system" id="ref-for-local-coordinate-system③">local coordinate system</a> for <var>sensor_instance</var> as the <a data-link-type="dfn" href="#screen-coordinate-system" id="ref-for-screen-coordinate-system④">screen coordinate system</a>.</p>
+        <p>Define <a data-link-type="dfn" href="https://w3c.github.io/sensors#local-coordinate-system" id="ref-for-local-coordinate-system③">local coordinate system</a> for <var>sensor_instance</var> as the <a data-link-type="dfn" href="#screen-coordinate-system" id="ref-for-screen-coordinate-system④">screen coordinate system</a>.</p>
       </ol>
      <li data-md="">
-      <p>Otherwise, define <a data-link-type="dfn" href="https://drafts.csswg.org/css-transforms-1/#local-coordinate-system" id="ref-for-local-coordinate-system④">local coordinate system</a> for <var>sensor_instance</var> as the <a data-link-type="dfn" href="#device-coordinate-system" id="ref-for-device-coordinate-system④">device coordinate system</a>.</p>
+      <p>Otherwise, define <a data-link-type="dfn" href="https://w3c.github.io/sensors#local-coordinate-system" id="ref-for-local-coordinate-system④">local coordinate system</a> for <var>sensor_instance</var> as the <a data-link-type="dfn" href="#device-coordinate-system" id="ref-for-device-coordinate-system④">device coordinate system</a>.</p>
     </ol>
    </div>
    <h3 class="heading settled" data-level="6.2" id="accelerometer-interface"><span class="secno">6.2. </span><span class="content">The Accelerometer Interface</span><a class="self-link" href="#accelerometer-interface"></a></h3>
@@ -1741,11 +1741,6 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
   <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
   <ul class="index">
    <li>
-    <a data-link-type="biblio">[css-transforms-1]</a> defines the following terms:
-    <ul>
-     <li><a href="https://drafts.csswg.org/css-transforms-1/#local-coordinate-system">local coordinate system</a>
-    </ul>
-   <li>
     <a data-link-type="biblio">[GENERIC-SENSOR]</a> defines the following terms:
     <ul>
      <li><a href="https://w3c.github.io/sensors/#sensor">Sensor</a>
@@ -1754,6 +1749,7 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
      <li><a href="https://w3c.github.io/sensors#default-sensor">default sensor</a>
      <li><a href="https://w3c.github.io/sensors/#get-value-from-latest-reading">get value from latest reading</a>
      <li><a href="https://w3c.github.io/sensors#latest-reading">latest reading</a>
+     <li><a href="https://w3c.github.io/sensors#local-coordinate-system">local coordinate system</a>
      <li><a href="https://w3c.github.io/sensors#sensor-type">sensor type</a>
     </ul>
    <li>
@@ -1786,8 +1782,6 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
   <h3 class="no-num no-ref heading settled" id="normative"><span class="content">Normative References</span><a class="self-link" href="#normative"></a></h3>
   <dl>
-   <dt id="biblio-css-transforms-1">[CSS-TRANSFORMS-1]
-   <dd>Simon Fraser; et al. <a href="https://drafts.csswg.org/css-transforms/">CSS Transforms Module Level 1</a>. URL: <a href="https://drafts.csswg.org/css-transforms/">https://drafts.csswg.org/css-transforms/</a>
    <dt id="biblio-generic-sensor">[GENERIC-SENSOR]
    <dd>Rick Waldron; et al. <a href="https://w3c.github.io/sensors/">Generic Sensor API</a>. URL: <a href="https://w3c.github.io/sensors/">https://w3c.github.io/sensors/</a>
    <dt id="biblio-infra">[INFRA]


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/pozdnyakov/accelerometer/pull/32.html" title="Last updated on Feb 1, 2018, 1:29 PM GMT (9283843)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/accelerometer/32/a7455d3...pozdnyakov:9283843.html" title="Last updated on Feb 1, 2018, 1:29 PM GMT (9283843)">Diff</a>