### PR TITLE
Remove some extra whitespace in IDL

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -264,7 +264,7 @@ The Accelerometer Interface {#accelerometer-interface}
 
   enum AccelerometerLocalCoordinateSystem { "device", "screen" };
 
-  dictionary AccelerometerSensorOptions :  SensorOptions  {
+  dictionary AccelerometerSensorOptions : SensorOptions {
     AccelerometerLocalCoordinateSystem referenceFrame = "device";
   };
 </pre>


### PR DESCRIPTION
Found by trying to sync the IDL in web-platform-tests with the spec:
https://github.com/w3c/web-platform-tests/pull/9757


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/foolip/accelerometer/pull/43.html" title="Last updated on Mar 2, 2018, 8:39 PM GMT (564f921)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/accelerometer/43/823f6f7...foolip:564f921.html" title="Last updated on Mar 2, 2018, 8:39 PM GMT (564f921)">Diff</a>