### PR TITLE
Fix broken links and fragments, avoid redundant redirects

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -25,7 +25,7 @@ Default Biblio Status: current
 Note class: note
 </pre>
 <pre class="anchors">
-urlPrefix: https://w3c.github.io/sensors; spec: GENERIC-SENSOR
+urlPrefix: https://w3c.github.io/sensors/; spec: GENERIC-SENSOR
   type: dfn
     text: high-level
     text: sensor
@@ -34,7 +34,7 @@ urlPrefix: https://w3c.github.io/sensors; spec: GENERIC-SENSOR
     text: initialize a sensor object; url: initialize-a-sensor-object
     text: sensor type
     text: local coordinate system
-    text: sensor readings; url: sensor-readings
+    text: sensor readings; url: sensor-reading
     text: check sensor policy-controlled features; url: check-sensor-policy-controlled-features
     text: location tracking; url: location-tracking
     text: keylogging; url: keystroke-monitoring
@@ -43,7 +43,7 @@ urlPrefix: https://w3c.github.io/sensors; spec: GENERIC-SENSOR
     text: generic mitigations; url: mitigation-strategies
     text: sensor permission name; url: sensor-permission-names
     text: supported sensor options
-urlPrefix: https://w3c.github.io/screen-orientation; spec: SCREEN-ORIENTATION
+urlPrefix: https://www.w3.org/TR/screen-orientation/; spec: SCREEN-ORIENTATION
   type: dfn
     text: current orientation type;  url: dfn-current-orientation-type
     text: dom screen; url: dom-screen

--- a/index.html
+++ b/index.html
@@ -1183,8 +1183,9 @@ Possible extra rowspan handling
       background-attachment: fixed;
     }
   </style>
-  <meta content="Bikeshed version 5afc3ab5248efd53ff0fd6d61ad878a3dc5a357a" name="generator">
+  <meta content="Bikeshed version 66a76cd06d4fa9e491630583356008a71a166760" name="generator">
   <link href="https://www.w3.org/TR/accelerometer/" rel="canonical">
+  <meta content="c7317cb5c17d92e1f0a86d81a6b99e1367deeed8" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1550,7 +1551,7 @@ of a device that hosts the sensor.</p>
   <main>
    <h2 class="heading settled" data-level="1" id="intro"><span class="secno">1. </span><span class="content">Introduction</span><a class="self-link" href="#intro"></a></h2>
    <p>The <code class="idl"><a data-link-type="idl" href="#accelerometer" id="ref-for-accelerometer①">Accelerometer</a></code>, <code class="idl"><a data-link-type="idl" href="#linearaccelerationsensor" id="ref-for-linearaccelerationsensor①">LinearAccelerationSensor</a></code> and <code class="idl"><a data-link-type="idl" href="#gravitysensor" id="ref-for-gravitysensor①">GravitySensor</a></code> APIs extends the Generic Sensor API <a data-link-type="biblio" href="#biblio-generic-sensor">[GENERIC-SENSOR]</a> interface to provide information about <a data-link-type="dfn" href="#acceleration" id="ref-for-acceleration①">acceleration</a> applied to device’s
-X, Y and Z axis in <a data-link-type="dfn" href="https://w3c.github.io/sensors#local-coordinate-system" id="ref-for-local-coordinate-system">local coordinate system</a> defined by device.</p>
+X, Y and Z axis in <a data-link-type="dfn" href="https://w3c.github.io/sensors/#local-coordinate-system" id="ref-for-local-coordinate-system">local coordinate system</a> defined by device.</p>
    <h2 class="heading settled" data-level="2" id="examples"><span class="secno">2. </span><span class="content">Examples</span><a class="self-link" href="#examples"></a></h2>
    <div class="example" id="example-a07da87c">
     <a class="self-link" href="#example-a07da87c"></a> 
@@ -1569,7 +1570,7 @@ sensor<span class="p">.</span>onerror <span class="o">=</span> event <span class
    <div class="example" id="example-67e56c83">
     <a class="self-link" href="#example-67e56c83"></a> The following example shows how to use gravity sensor that provides
     readings in the <a data-link-type="dfn" href="#screen-coordinate-system" id="ref-for-screen-coordinate-system">screen coordinate system</a>. The snippet will print message to the
-    console when the <a data-link-type="dfn" href="https://w3c.github.io/screen-orientation#dom-screen" id="ref-for-dom-screen">dom screen</a> is perpendicular to the ground and bottom of the
+    console when the <a data-link-type="dfn" href="https://www.w3.org/TR/screen-orientation/#dom-screen" id="ref-for-dom-screen">dom screen</a> is perpendicular to the ground and bottom of the
     rendered web page is pointing downwards. 
 <pre class="highlight"><span class="kd">let</span> sensor <span class="o">=</span> <span class="k">new</span> GravitySensor<span class="p">({</span>frequency<span class="o">:</span> <span class="mi">5</span><span class="p">,</span> referenceFrame<span class="o">:</span> <span class="s2">"screen"</span><span class="p">});</span>
 
@@ -1584,7 +1585,7 @@ sensor<span class="p">.</span>start<span class="p">();</span>
    </div>
    <div class="example" id="example-9c43849a">
     <a class="self-link" href="#example-9c43849a"></a> The following example detects shake gesture along x axis of the device, regardless
-    of the orientation of the <a data-link-type="dfn" href="https://w3c.github.io/screen-orientation#dom-screen" id="ref-for-dom-screen①">dom screen</a>. 
+    of the orientation of the <a data-link-type="dfn" href="https://www.w3.org/TR/screen-orientation/#dom-screen" id="ref-for-dom-screen①">dom screen</a>. 
 <pre class="highlight"><span class="kr">const</span> shakeThreshold <span class="o">=</span> <span class="mi">25</span><span class="p">;</span>
 
 <span class="kd">let</span> sensor <span class="o">=</span> <span class="k">new</span> LinearAccelerationSensor<span class="p">({</span>frequency<span class="o">:</span> <span class="mi">60</span><span class="p">});</span>
@@ -1601,34 +1602,34 @@ sensor<span class="p">.</span>start<span class="p">();</span>
    <h2 class="heading settled" data-level="3" id="usecases-requirements"><span class="secno">3. </span><span class="content">Use Cases and Requirements</span><a class="self-link" href="#usecases-requirements"></a></h2>
    <p>The use cases and requirements are listed in the <cite><a href="https://w3c.github.io/motion-sensors/#usecases-and-requirements"> Motion Sensors Explainer</a></cite> and <cite><a href="https://w3c.github.io/sensors/usecases.html"> Sensor use cases</a></cite> documents.</p>
    <h2 class="heading settled" data-level="4" id="security-and-privacy"><span class="secno">4. </span><span class="content">Security and Privacy Considerations</span><a class="self-link" href="#security-and-privacy"></a></h2>
-   <p><a data-link-type="dfn" href="https://w3c.github.io/sensors#sensor-readings" id="ref-for-sensor-readings">Sensor readings</a> provided by inertial sensors, such as accelerometer, could be used by adversaries
-to exploit various security threats, for example, <a data-link-type="dfn" href="https://w3c.github.io/sensors#keystroke-monitoring" id="ref-for-keystroke-monitoring">keylogging</a>, <a data-link-type="dfn" href="https://w3c.github.io/sensors#location-tracking" id="ref-for-location-tracking">location tracking</a>, <a data-link-type="dfn" href="https://w3c.github.io/sensors#device-fingerprinting" id="ref-for-device-fingerprinting">fingerprinting</a> and <a data-link-type="dfn" href="https://w3c.github.io/sensors#user-identifying" id="ref-for-user-identifying">user identifying</a>.</p>
+   <p><a data-link-type="dfn" href="https://w3c.github.io/sensors/#sensor-reading" id="ref-for-sensor-reading">Sensor readings</a> provided by inertial sensors, such as accelerometer, could be used by adversaries
+to exploit various security threats, for example, <a data-link-type="dfn" href="https://w3c.github.io/sensors/#keystroke-monitoring" id="ref-for-keystroke-monitoring">keylogging</a>, <a data-link-type="dfn" href="https://w3c.github.io/sensors/#location-tracking" id="ref-for-location-tracking">location tracking</a>, <a data-link-type="dfn" href="https://w3c.github.io/sensors/#device-fingerprinting" id="ref-for-device-fingerprinting">fingerprinting</a> and <a data-link-type="dfn" href="https://w3c.github.io/sensors/#user-identifying" id="ref-for-user-identifying">user identifying</a>.</p>
    <p>Research papers published by security community, for instance, <a data-link-type="biblio" href="#biblio-keystrokedefense">[KEYSTROKEDEFENSE]</a>, indicate that
 by throttling the frequency, risks of successful attacks are not fully eliminated, while throttling
 may greatly affect usefulness of a web application with legitimate reasons to use the sensors.</p>
    <p>The <a data-link-type="biblio" href="#biblio-touchsignatures">[TOUCHSIGNATURES]</a> and <a data-link-type="biblio" href="#biblio-accessory">[ACCESSORY]</a> research papers propose that implementations can
 provide visual indication when inertial sensors are in use and/or require explicit user consent to
-access <a data-link-type="dfn" href="https://w3c.github.io/sensors#sensor-readings" id="ref-for-sensor-readings①">sensor readings</a>. These mitigation strategies complement the <a data-link-type="dfn" href="https://w3c.github.io/sensors#mitigation-strategies" id="ref-for-mitigation-strategies">generic mitigations</a> defined
+access <a data-link-type="dfn" href="https://w3c.github.io/sensors/#sensor-reading" id="ref-for-sensor-reading①">sensor readings</a>. These mitigation strategies complement the <a data-link-type="dfn" href="https://w3c.github.io/sensors/#mitigation-strategies" id="ref-for-mitigation-strategies">generic mitigations</a> defined
 in the Generic Sensor API <a data-link-type="biblio" href="#biblio-generic-sensor">[GENERIC-SENSOR]</a>.</p>
    <h2 class="heading settled" data-level="5" id="model"><span class="secno">5. </span><span class="content">Model</span><a class="self-link" href="#model"></a></h2>
-   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="accelerometer-sensor-type">Accelerometer</dfn> <a data-link-type="dfn" href="https://w3c.github.io/sensors#sensor-type" id="ref-for-sensor-type">sensor type</a>’s associated <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/sensors/#sensor" id="ref-for-sensor">Sensor</a></code> subclass is the <code class="idl"><a data-link-type="idl" href="#accelerometer" id="ref-for-accelerometer②">Accelerometer</a></code> class.</p>
-   <p>The <a data-link-type="dfn" href="#accelerometer-sensor-type" id="ref-for-accelerometer-sensor-type">Accelerometer</a> has a <a data-link-type="dfn" href="https://w3c.github.io/sensors#default-sensor" id="ref-for-default-sensor">default sensor</a>, which is the device’s main accelerometer sensor.</p>
-   <p>The <a data-link-type="dfn" href="#accelerometer-sensor-type" id="ref-for-accelerometer-sensor-type①">Accelerometer</a> has an associated <a data-link-type="dfn" href="https://w3c.github.io/sensors#sensor-permission-names" id="ref-for-sensor-permission-names">sensor permission name</a> which is <a class="idl-code" data-link-type="enum-value" href="https://w3c.github.io/permissions/#dom-permissionname-accelerometer" id="ref-for-dom-permissionname-accelerometer">"accelerometer"</a>.</p>
-   <p>A <a data-link-type="dfn" href="https://w3c.github.io/sensors#latest-reading" id="ref-for-latest-reading">latest reading</a> for a <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/sensors/#sensor" id="ref-for-sensor①">Sensor</a></code> of <a data-link-type="dfn" href="#accelerometer-sensor-type" id="ref-for-accelerometer-sensor-type②">Accelerometer</a> <a data-link-type="dfn" href="https://w3c.github.io/sensors#sensor-type" id="ref-for-sensor-type①">sensor type</a> includes three <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry" id="ref-for-map-entry">entries</a> whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-key" id="ref-for-map-key">keys</a> are "x", "y", "z" and whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-value" id="ref-for-map-value">values</a> contain device’s <a data-link-type="dfn" href="#acceleration" id="ref-for-acceleration②">acceleration</a> about the corresponding axes. Values can contain also device’s <a data-link-type="dfn" href="#linear-acceleration" id="ref-for-linear-acceleration">linear acceleration</a> or <a data-link-type="dfn" href="#gravity" id="ref-for-gravity">gravity</a> depending on which object was instantiated.</p>
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="accelerometer-sensor-type">Accelerometer</dfn> <a data-link-type="dfn" href="https://w3c.github.io/sensors/#sensor-type" id="ref-for-sensor-type">sensor type</a>’s associated <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/sensors/#sensor" id="ref-for-sensor">Sensor</a></code> subclass is the <code class="idl"><a data-link-type="idl" href="#accelerometer" id="ref-for-accelerometer②">Accelerometer</a></code> class.</p>
+   <p>The <a data-link-type="dfn" href="#accelerometer-sensor-type" id="ref-for-accelerometer-sensor-type">Accelerometer</a> has a <a data-link-type="dfn" href="https://w3c.github.io/sensors/#default-sensor" id="ref-for-default-sensor">default sensor</a>, which is the device’s main accelerometer sensor.</p>
+   <p>The <a data-link-type="dfn" href="#accelerometer-sensor-type" id="ref-for-accelerometer-sensor-type①">Accelerometer</a> has an associated <a data-link-type="dfn" href="https://w3c.github.io/sensors/#sensor-permission-names" id="ref-for-sensor-permission-names">sensor permission name</a> which is <a class="idl-code" data-link-type="enum-value" href="https://w3c.github.io/permissions/#dom-permissionname-accelerometer" id="ref-for-dom-permissionname-accelerometer">"accelerometer"</a>.</p>
+   <p>A <a data-link-type="dfn" href="https://w3c.github.io/sensors/#latest-reading" id="ref-for-latest-reading">latest reading</a> for a <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/sensors/#sensor" id="ref-for-sensor①">Sensor</a></code> of <a data-link-type="dfn" href="#accelerometer-sensor-type" id="ref-for-accelerometer-sensor-type②">Accelerometer</a> <a data-link-type="dfn" href="https://w3c.github.io/sensors/#sensor-type" id="ref-for-sensor-type①">sensor type</a> includes three <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry" id="ref-for-map-entry">entries</a> whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-key" id="ref-for-map-key">keys</a> are "x", "y", "z" and whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-value" id="ref-for-map-value">values</a> contain device’s <a data-link-type="dfn" href="#acceleration" id="ref-for-acceleration②">acceleration</a> about the corresponding axes. Values can contain also device’s <a data-link-type="dfn" href="#linear-acceleration" id="ref-for-linear-acceleration">linear acceleration</a> or <a data-link-type="dfn" href="#gravity" id="ref-for-gravity">gravity</a> depending on which object was instantiated.</p>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="acceleration">acceleration</dfn> is the rate of change of velocity of a device with respect to time. Its
 unit is the metre per second squared (m/s<sup>2</sup>) <a data-link-type="biblio" href="#biblio-si">[SI]</a>.</p>
    <p>The frame of reference for the <a data-link-type="dfn" href="#acceleration" id="ref-for-acceleration③">acceleration</a> measurement must be inertial, such as, the device in free fall would
 provide 0 (m/s<sup>2</sup>) <a data-link-type="dfn" href="#acceleration" id="ref-for-acceleration④">acceleration</a> value for each axis.</p>
-   <p>The sign of the <a data-link-type="dfn" href="#acceleration" id="ref-for-acceleration⑤">acceleration</a> values must be according to the right-hand convention in a <a data-link-type="dfn" href="https://w3c.github.io/sensors#local-coordinate-system" id="ref-for-local-coordinate-system①">local coordinate
+   <p>The sign of the <a data-link-type="dfn" href="#acceleration" id="ref-for-acceleration⑤">acceleration</a> values must be according to the right-hand convention in a <a data-link-type="dfn" href="https://w3c.github.io/sensors/#local-coordinate-system" id="ref-for-local-coordinate-system①">local coordinate
 system</a> (see figure below).</p>
    <p><img alt="Accelerometer coordinate system." onerror="this.src=&apos;images/accelerometer_coordinate_system.png&apos;" src="images/accelerometer_coordinate_system.svg" style="display: block;margin: auto;"></p>
-   <p>The <code class="idl"><a data-link-type="idl" href="#linearaccelerationsensor" id="ref-for-linearaccelerationsensor②">LinearAccelerationSensor</a></code> class is an <code class="idl"><a data-link-type="idl" href="#accelerometer" id="ref-for-accelerometer③">Accelerometer</a></code>'s subclass. The <code class="idl"><a data-link-type="idl" href="#linearaccelerationsensor" id="ref-for-linearaccelerationsensor③">LinearAccelerationSensor</a></code>'s <a data-link-type="dfn" href="https://w3c.github.io/sensors#latest-reading" id="ref-for-latest-reading①">latest reading</a> contains device’s <a data-link-type="dfn" href="#linear-acceleration" id="ref-for-linear-acceleration①">linear acceleration</a> about the corresponding axes.</p>
+   <p>The <code class="idl"><a data-link-type="idl" href="#linearaccelerationsensor" id="ref-for-linearaccelerationsensor②">LinearAccelerationSensor</a></code> class is an <code class="idl"><a data-link-type="idl" href="#accelerometer" id="ref-for-accelerometer③">Accelerometer</a></code>'s subclass. The <code class="idl"><a data-link-type="idl" href="#linearaccelerationsensor" id="ref-for-linearaccelerationsensor③">LinearAccelerationSensor</a></code>'s <a data-link-type="dfn" href="https://w3c.github.io/sensors/#latest-reading" id="ref-for-latest-reading①">latest reading</a> contains device’s <a data-link-type="dfn" href="#linear-acceleration" id="ref-for-linear-acceleration①">linear acceleration</a> about the corresponding axes.</p>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="linear-acceleration">linear acceleration</dfn> is an <a data-link-type="dfn" href="#acceleration" id="ref-for-acceleration⑥">acceleration</a> that is applied to the device that hosts
 the sensor, without the contribution of a <a data-link-type="dfn" href="#gravity" id="ref-for-gravity①">gravity</a> force.</p>
-   <p>The <code class="idl"><a data-link-type="idl" href="#gravitysensor" id="ref-for-gravitysensor②">GravitySensor</a></code> class is an <code class="idl"><a data-link-type="idl" href="#accelerometer" id="ref-for-accelerometer④">Accelerometer</a></code>'s subclass. The <code class="idl"><a data-link-type="idl" href="#gravitysensor" id="ref-for-gravitysensor③">GravitySensor</a></code>'s <a data-link-type="dfn" href="https://w3c.github.io/sensors#latest-reading" id="ref-for-latest-reading②">latest reading</a> contains device’s <a data-link-type="dfn" href="#acceleration" id="ref-for-acceleration⑦">acceleration</a> due to the effect of <a data-link-type="dfn" href="#gravity" id="ref-for-gravity②">gravity</a> force about the corresponding axes.</p>
+   <p>The <code class="idl"><a data-link-type="idl" href="#gravitysensor" id="ref-for-gravitysensor②">GravitySensor</a></code> class is an <code class="idl"><a data-link-type="idl" href="#accelerometer" id="ref-for-accelerometer④">Accelerometer</a></code>'s subclass. The <code class="idl"><a data-link-type="idl" href="#gravitysensor" id="ref-for-gravitysensor③">GravitySensor</a></code>'s <a data-link-type="dfn" href="https://w3c.github.io/sensors/#latest-reading" id="ref-for-latest-reading②">latest reading</a> contains device’s <a data-link-type="dfn" href="#acceleration" id="ref-for-acceleration⑦">acceleration</a> due to the effect of <a data-link-type="dfn" href="#gravity" id="ref-for-gravity②">gravity</a> force about the corresponding axes.</p>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="gravity">gravity</dfn> is a force that attracts an object to the center of the earth, or towards any other physical object having mass.</p>
    <h3 class="heading settled" data-level="5.1" id="reference-frame"><span class="secno">5.1. </span><span class="content">Reference Frame</span><a class="self-link" href="#reference-frame"></a></h3>
-   <p>The <a data-link-type="dfn" href="https://w3c.github.io/sensors#local-coordinate-system" id="ref-for-local-coordinate-system②">local coordinate system</a> represents the reference frame for the <code class="idl"><a data-link-type="idl" href="#accelerometer" id="ref-for-accelerometer⑤">Accelerometer</a></code>, <code class="idl"><a data-link-type="idl" href="#linearaccelerationsensor" id="ref-for-linearaccelerationsensor④">LinearAccelerationSensor</a></code>, and the <code class="idl"><a data-link-type="idl" href="#gravitysensor" id="ref-for-gravitysensor④">GravitySensor</a></code> <a data-link-type="dfn" href="https://w3c.github.io/sensors#sensor-readings" id="ref-for-sensor-readings②">readings</a>. It can be either the <a data-link-type="dfn" href="#device-coordinate-system" id="ref-for-device-coordinate-system">device coordinate system</a> or the <a data-link-type="dfn" href="#screen-coordinate-system" id="ref-for-screen-coordinate-system①">screen coordinate system</a>.</p>
+   <p>The <a data-link-type="dfn" href="https://w3c.github.io/sensors/#local-coordinate-system" id="ref-for-local-coordinate-system②">local coordinate system</a> represents the reference frame for the <code class="idl"><a data-link-type="idl" href="#accelerometer" id="ref-for-accelerometer⑤">Accelerometer</a></code>, <code class="idl"><a data-link-type="idl" href="#linearaccelerationsensor" id="ref-for-linearaccelerationsensor④">LinearAccelerationSensor</a></code>, and the <code class="idl"><a data-link-type="idl" href="#gravitysensor" id="ref-for-gravitysensor④">GravitySensor</a></code> <a data-link-type="dfn" href="https://w3c.github.io/sensors/#sensor-reading" id="ref-for-sensor-reading②">readings</a>. It can be either the <a data-link-type="dfn" href="#device-coordinate-system" id="ref-for-device-coordinate-system">device coordinate system</a> or the <a data-link-type="dfn" href="#screen-coordinate-system" id="ref-for-screen-coordinate-system①">screen coordinate system</a>.</p>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="device-coordinate-system">device coordinate system</dfn> is defined as a three dimensional
 Cartesian coordinate system (x, y, z), which is bound to the physical device.
 For devices with a display, the origin of the <a data-link-type="dfn" href="#device-coordinate-system" id="ref-for-device-coordinate-system①">device coordinate system</a> is
@@ -1636,19 +1637,19 @@ the center of the device display. If the device is held in its default position,
 the Y-axis points towards the top of the display, the X-axis points towards the right of
 the display and Z-axis is the vector product of X and Y axes and it points outwards from
 the display, and towards the viewer. The <a data-link-type="dfn" href="#device-coordinate-system" id="ref-for-device-coordinate-system②">device coordinate system</a> remains stationary
-regardless of the <a data-link-type="dfn" href="https://w3c.github.io/screen-orientation#dom-screen" id="ref-for-dom-screen②">dom screen</a> orientation (see figure below).</p>
+regardless of the <a data-link-type="dfn" href="https://www.w3.org/TR/screen-orientation/#dom-screen" id="ref-for-dom-screen②">dom screen</a> orientation (see figure below).</p>
    <p><img alt="Device coordinate system." onerror="this.src=&apos;images/device_coordinate_system.png&apos;" src="images/device_coordinate_system.svg" style="display: block;margin: auto;"></p>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="screen-coordinate-system">screen coordinate system</dfn> is defined as a three dimensional
-Cartesian coordinate system (x, y, z), which is bound to the <a data-link-type="dfn" href="https://w3c.github.io/screen-orientation#dom-screen" id="ref-for-dom-screen③">dom screen</a>.
+Cartesian coordinate system (x, y, z), which is bound to the <a data-link-type="dfn" href="https://www.w3.org/TR/screen-orientation/#dom-screen" id="ref-for-dom-screen③">dom screen</a>.
 The origin of the <a data-link-type="dfn" href="#screen-coordinate-system" id="ref-for-screen-coordinate-system②">screen coordinate system</a> in the center
-of the <a data-link-type="dfn" href="https://w3c.github.io/screen-orientation#dom-screen" id="ref-for-dom-screen④">dom screen</a>. The Y-axis always points towards the top of the <a data-link-type="dfn" href="https://w3c.github.io/screen-orientation#dom-screen" id="ref-for-dom-screen⑤">dom screen</a>,
-the X-axis points towards the right of the <a data-link-type="dfn" href="https://w3c.github.io/screen-orientation#dom-screen" id="ref-for-dom-screen⑥">dom screen</a> and Z-axis is the
-vector product of X and Y axes and it and it points outwards from the <a data-link-type="dfn" href="https://w3c.github.io/screen-orientation#dom-screen" id="ref-for-dom-screen⑦">dom screen</a>,
+of the <a data-link-type="dfn" href="https://www.w3.org/TR/screen-orientation/#dom-screen" id="ref-for-dom-screen④">dom screen</a>. The Y-axis always points towards the top of the <a data-link-type="dfn" href="https://www.w3.org/TR/screen-orientation/#dom-screen" id="ref-for-dom-screen⑤">dom screen</a>,
+the X-axis points towards the right of the <a data-link-type="dfn" href="https://www.w3.org/TR/screen-orientation/#dom-screen" id="ref-for-dom-screen⑥">dom screen</a> and Z-axis is the
+vector product of X and Y axes and it and it points outwards from the <a data-link-type="dfn" href="https://www.w3.org/TR/screen-orientation/#dom-screen" id="ref-for-dom-screen⑦">dom screen</a>,
 and towards the viewer (see figure below).</p>
    <p><img alt="Screen coordinate system." onerror="this.src=&apos;images/screen_coordinate_system.png&apos;" src="images/screen_coordinate_system.svg" style="display: block;margin: auto;"></p>
    <p>The main difference between the <a data-link-type="dfn" href="#device-coordinate-system" id="ref-for-device-coordinate-system③">device coordinate system</a> and the <a data-link-type="dfn" href="#screen-coordinate-system" id="ref-for-screen-coordinate-system③">screen coordinate system</a>,
-is that the <a data-link-type="dfn" href="#screen-coordinate-system" id="ref-for-screen-coordinate-system④">screen coordinate system</a> always follows the <a data-link-type="dfn" href="https://w3c.github.io/screen-orientation#dom-screen" id="ref-for-dom-screen⑧">dom screen</a> orientation,
-i.e. it will swap X and Y axes in relation to the device if the <a data-link-type="dfn" href="https://w3c.github.io/screen-orientation#dfn-current-orientation-type" id="ref-for-dfn-current-orientation-type">current orientation type</a> changes. In contrast, the <a data-link-type="dfn" href="#device-coordinate-system" id="ref-for-device-coordinate-system④">device coordinate system</a> will always remain stationary relative to
+is that the <a data-link-type="dfn" href="#screen-coordinate-system" id="ref-for-screen-coordinate-system④">screen coordinate system</a> always follows the <a data-link-type="dfn" href="https://www.w3.org/TR/screen-orientation/#dom-screen" id="ref-for-dom-screen⑧">dom screen</a> orientation,
+i.e. it will swap X and Y axes in relation to the device if the <a data-link-type="dfn" href="https://www.w3.org/TR/screen-orientation/#dfn-current-orientation-type" id="ref-for-dfn-current-orientation-type">current orientation type</a> changes. In contrast, the <a data-link-type="dfn" href="#device-coordinate-system" id="ref-for-device-coordinate-system④">device coordinate system</a> will always remain stationary relative to
 the device.</p>
    <h2 class="heading settled" data-level="6" id="api"><span class="secno">6. </span><span class="content">API</span><a class="self-link" href="#api"></a></h2>
    <h3 class="heading settled" data-level="6.1" id="accelerometer-interface"><span class="secno">6.1. </span><span class="content">The Accelerometer Interface</span><a class="self-link" href="#accelerometer-interface"></a></h3>
@@ -1668,7 +1669,7 @@ the device.</p>
 </pre>
    <p>To construct an <code class="idl"><a data-link-type="idl" href="#accelerometer" id="ref-for-accelerometer⑥">Accelerometer</a></code> object the user agent must invoke
 the <a data-link-type="dfn" href="#construct-an-accelerometer-object" id="ref-for-construct-an-accelerometer-object">construct an accelerometer object</a> abstract operation for the <code class="idl"><a data-link-type="idl" href="#accelerometer" id="ref-for-accelerometer⑦">Accelerometer</a></code> interface.</p>
-   <p><a data-link-type="dfn" href="https://w3c.github.io/sensors#supported-sensor-options" id="ref-for-supported-sensor-options">Supported sensor options</a> for <code class="idl"><a data-link-type="idl" href="#accelerometer" id="ref-for-accelerometer⑧">Accelerometer</a></code> are "frequency" and "referenceFrame".</p>
+   <p><a data-link-type="dfn" href="https://w3c.github.io/sensors/#supported-sensor-options" id="ref-for-supported-sensor-options">Supported sensor options</a> for <code class="idl"><a data-link-type="idl" href="#accelerometer" id="ref-for-accelerometer⑧">Accelerometer</a></code> are "frequency" and "referenceFrame".</p>
    <h4 class="heading settled" data-level="6.1.1" id="accelerometer-x"><span class="secno">6.1.1. </span><span class="content">Accelerometer.x</span><a class="self-link" href="#accelerometer-x"></a></h4>
    <p>The <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-accelerometer-x" id="ref-for-dom-accelerometer-x">x</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#accelerometer" id="ref-for-accelerometer⑨">Accelerometer</a></code> interface returns the result of invoking <a data-link-type="dfn" href="https://w3c.github.io/sensors/#get-value-from-latest-reading" id="ref-for-get-value-from-latest-reading">get value from latest reading</a> with <code>this</code> and "x" as arguments. It represents the <a data-link-type="dfn" href="#acceleration" id="ref-for-acceleration⑧">acceleration</a> along x-axis.</p>
    <h4 class="heading settled" data-level="6.1.2" id="accelerometer-y"><span class="secno">6.1.2. </span><span class="content">Accelerometer.y</span><a class="self-link" href="#accelerometer-y"></a></h4>
@@ -1683,7 +1684,7 @@ the <a data-link-type="dfn" href="#construct-an-accelerometer-object" id="ref-fo
 </pre>
    <p>To construct a <code class="idl"><a data-link-type="idl" href="#linearaccelerationsensor" id="ref-for-linearaccelerationsensor⑤">LinearAccelerationSensor</a></code> object the user agent must invoke
 the <a data-link-type="dfn" href="#construct-an-accelerometer-object" id="ref-for-construct-an-accelerometer-object①">construct an accelerometer object</a> abstract operation for the <code class="idl"><a data-link-type="idl" href="#linearaccelerationsensor" id="ref-for-linearaccelerationsensor⑥">LinearAccelerationSensor</a></code> interface.</p>
-   <p><a data-link-type="dfn" href="https://w3c.github.io/sensors#supported-sensor-options" id="ref-for-supported-sensor-options①">Supported sensor options</a> for <code class="idl"><a data-link-type="idl" href="#linearaccelerationsensor" id="ref-for-linearaccelerationsensor⑦">LinearAccelerationSensor</a></code> are "frequency" and "referenceFrame".</p>
+   <p><a data-link-type="dfn" href="https://w3c.github.io/sensors/#supported-sensor-options" id="ref-for-supported-sensor-options①">Supported sensor options</a> for <code class="idl"><a data-link-type="idl" href="#linearaccelerationsensor" id="ref-for-linearaccelerationsensor⑦">LinearAccelerationSensor</a></code> are "frequency" and "referenceFrame".</p>
    <h4 class="heading settled" data-level="6.2.1" id="linearaccelerationsensor-x"><span class="secno">6.2.1. </span><span class="content">LinearAccelerationSensor.x</span><a class="self-link" href="#linearaccelerationsensor-x"></a></h4>
    <p>The <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-accelerometer-x" id="ref-for-dom-accelerometer-x①">x</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#linearaccelerationsensor" id="ref-for-linearaccelerationsensor⑧">LinearAccelerationSensor</a></code> interface returns the result of invoking <a data-link-type="dfn" href="https://w3c.github.io/sensors/#get-value-from-latest-reading" id="ref-for-get-value-from-latest-reading③">get value from latest reading</a> with <code>this</code> and "x" as arguments. It represents the <a data-link-type="dfn" href="#linear-acceleration" id="ref-for-linear-acceleration②">linear acceleration</a> along x-axis.</p>
    <h4 class="heading settled" data-level="6.2.2" id="linearaccelerationsensor-y"><span class="secno">6.2.2. </span><span class="content">LinearAccelerationSensor.y</span><a class="self-link" href="#linearaccelerationsensor-y"></a></h4>
@@ -1698,7 +1699,7 @@ the <a data-link-type="dfn" href="#construct-an-accelerometer-object" id="ref-fo
 </pre>
    <p>To construct a <code class="idl"><a data-link-type="idl" href="#gravitysensor" id="ref-for-gravitysensor⑤">GravitySensor</a></code> object the user agent must invoke
 the <a data-link-type="dfn" href="#construct-an-accelerometer-object" id="ref-for-construct-an-accelerometer-object②">construct an accelerometer object</a> abstract operation for the <code class="idl"><a data-link-type="idl" href="#gravitysensor" id="ref-for-gravitysensor⑥">GravitySensor</a></code> interface.</p>
-   <p><a data-link-type="dfn" href="https://w3c.github.io/sensors#supported-sensor-options" id="ref-for-supported-sensor-options②">Supported sensor options</a> for <code class="idl"><a data-link-type="idl" href="#gravitysensor" id="ref-for-gravitysensor⑦">GravitySensor</a></code> are "frequency" and "referenceFrame".</p>
+   <p><a data-link-type="dfn" href="https://w3c.github.io/sensors/#supported-sensor-options" id="ref-for-supported-sensor-options②">Supported sensor options</a> for <code class="idl"><a data-link-type="idl" href="#gravitysensor" id="ref-for-gravitysensor⑦">GravitySensor</a></code> are "frequency" and "referenceFrame".</p>
    <h4 class="heading settled" data-level="6.3.1" id="gravitysensor-x"><span class="secno">6.3.1. </span><span class="content">GravitySensor.x</span><a class="self-link" href="#gravitysensor-x"></a></h4>
    <p>The <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-accelerometer-x" id="ref-for-dom-accelerometer-x②">x</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#gravitysensor" id="ref-for-gravitysensor⑧">GravitySensor</a></code> interface returns the result of invoking <a data-link-type="dfn" href="https://w3c.github.io/sensors/#get-value-from-latest-reading" id="ref-for-get-value-from-latest-reading⑥">get value from latest reading</a> with <code>this</code> and "x" as arguments. It represents the effect of <a data-link-type="dfn" href="#acceleration" id="ref-for-acceleration①①">acceleration</a> along x-axis due to <a data-link-type="dfn" href="#gravity" id="ref-for-gravity③">gravity</a>.</p>
    <h4 class="heading settled" data-level="6.3.2" id="gravitysensor-y"><span class="secno">6.3.2. </span><span class="content">GravitySensor.y</span><a class="self-link" href="#gravitysensor-y"></a></h4>
@@ -1721,7 +1722,7 @@ the <a data-link-type="dfn" href="#construct-an-accelerometer-object" id="ref-fo
     </dl>
     <ol>
      <li data-md="">
-      <p>Let <var>allowed</var> be the result of invoking <a data-link-type="dfn" href="https://w3c.github.io/sensors#check-sensor-policy-controlled-features" id="ref-for-check-sensor-policy-controlled-features">check sensor policy-controlled features</a> with <a data-link-type="dfn" href="#accelerometer-sensor-type" id="ref-for-accelerometer-sensor-type③">Accelerometer</a>.</p>
+      <p>Let <var>allowed</var> be the result of invoking <a data-link-type="dfn" href="https://w3c.github.io/sensors/#check-sensor-policy-controlled-features" id="ref-for-check-sensor-policy-controlled-features">check sensor policy-controlled features</a> with <a data-link-type="dfn" href="#accelerometer-sensor-type" id="ref-for-accelerometer-sensor-type③">Accelerometer</a>.</p>
      <li data-md="">
       <p>If <var>allowed</var> is false, then:</p>
       <ol>
@@ -1731,15 +1732,15 @@ the <a data-link-type="dfn" href="#construct-an-accelerometer-object" id="ref-fo
      <li data-md="">
       <p>Let <var>accelerometer</var> be a new instance of the <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface" id="ref-for-dfn-interface②">interface</a> identified by <var>accelerometer_interface</var>.</p>
      <li data-md="">
-      <p>Invoke <a data-link-type="dfn" href="https://w3c.github.io/sensors#initialize-a-sensor-object" id="ref-for-initialize-a-sensor-object">initialize a sensor object</a> with <var>accelerometer</var> and <var>options</var>.</p>
+      <p>Invoke <a data-link-type="dfn" href="https://w3c.github.io/sensors/#initialize-a-sensor-object" id="ref-for-initialize-a-sensor-object">initialize a sensor object</a> with <var>accelerometer</var> and <var>options</var>.</p>
      <li data-md="">
       <p>If <var>options</var>.<code class="idl"><a class="idl-code" data-link-type="dict-member" href="#dom-accelerometersensoroptions-referenceframe" id="ref-for-dom-accelerometersensoroptions-referenceframe">referenceFrame</a></code> is "screen", then:</p>
       <ol>
        <li data-md="">
-        <p>Define <a data-link-type="dfn" href="https://w3c.github.io/sensors#local-coordinate-system" id="ref-for-local-coordinate-system③">local coordinate system</a> for <var>accelerometer</var> as the <a data-link-type="dfn" href="#screen-coordinate-system" id="ref-for-screen-coordinate-system⑤">screen coordinate system</a>.</p>
+        <p>Define <a data-link-type="dfn" href="https://w3c.github.io/sensors/#local-coordinate-system" id="ref-for-local-coordinate-system③">local coordinate system</a> for <var>accelerometer</var> as the <a data-link-type="dfn" href="#screen-coordinate-system" id="ref-for-screen-coordinate-system⑤">screen coordinate system</a>.</p>
       </ol>
      <li data-md="">
-      <p>Otherwise, define <a data-link-type="dfn" href="https://w3c.github.io/sensors#local-coordinate-system" id="ref-for-local-coordinate-system④">local coordinate system</a> for <var>accelerometer</var> as the <a data-link-type="dfn" href="#device-coordinate-system" id="ref-for-device-coordinate-system⑤">device coordinate system</a>.</p>
+      <p>Otherwise, define <a data-link-type="dfn" href="https://w3c.github.io/sensors/#local-coordinate-system" id="ref-for-local-coordinate-system④">local coordinate system</a> for <var>accelerometer</var> as the <a data-link-type="dfn" href="#device-coordinate-system" id="ref-for-device-coordinate-system⑤">device coordinate system</a>.</p>
      <li data-md="">
       <p>Return <var>accelerometer</var>.</p>
     </ol>
@@ -1804,21 +1805,21 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
     <ul>
      <li><a href="https://w3c.github.io/sensors/#sensor">Sensor</a>
      <li><a href="https://w3c.github.io/sensors/#dictdef-sensoroptions">SensorOptions</a>
-     <li><a href="https://w3c.github.io/sensors#check-sensor-policy-controlled-features">check sensor policy-controlled features</a>
-     <li><a href="https://w3c.github.io/sensors#default-sensor">default sensor</a>
-     <li><a href="https://w3c.github.io/sensors#device-fingerprinting">fingerprinting</a>
-     <li><a href="https://w3c.github.io/sensors#mitigation-strategies">generic mitigations</a>
+     <li><a href="https://w3c.github.io/sensors/#check-sensor-policy-controlled-features">check sensor policy-controlled features</a>
+     <li><a href="https://w3c.github.io/sensors/#default-sensor">default sensor</a>
+     <li><a href="https://w3c.github.io/sensors/#device-fingerprinting">fingerprinting</a>
+     <li><a href="https://w3c.github.io/sensors/#mitigation-strategies">generic mitigations</a>
      <li><a href="https://w3c.github.io/sensors/#get-value-from-latest-reading">get value from latest reading</a>
-     <li><a href="https://w3c.github.io/sensors#initialize-a-sensor-object">initialize a sensor object</a>
-     <li><a href="https://w3c.github.io/sensors#keystroke-monitoring">keylogging</a>
-     <li><a href="https://w3c.github.io/sensors#latest-reading">latest reading</a>
-     <li><a href="https://w3c.github.io/sensors#local-coordinate-system">local coordinate system</a>
-     <li><a href="https://w3c.github.io/sensors#location-tracking">location tracking</a>
-     <li><a href="https://w3c.github.io/sensors#sensor-permission-names">sensor permission name</a>
-     <li><a href="https://w3c.github.io/sensors#sensor-readings">sensor readings</a>
-     <li><a href="https://w3c.github.io/sensors#sensor-type">sensor type</a>
-     <li><a href="https://w3c.github.io/sensors#supported-sensor-options">supported sensor options</a>
-     <li><a href="https://w3c.github.io/sensors#user-identifying">user identifying</a>
+     <li><a href="https://w3c.github.io/sensors/#initialize-a-sensor-object">initialize a sensor object</a>
+     <li><a href="https://w3c.github.io/sensors/#keystroke-monitoring">keylogging</a>
+     <li><a href="https://w3c.github.io/sensors/#latest-reading">latest reading</a>
+     <li><a href="https://w3c.github.io/sensors/#local-coordinate-system">local coordinate system</a>
+     <li><a href="https://w3c.github.io/sensors/#location-tracking">location tracking</a>
+     <li><a href="https://w3c.github.io/sensors/#sensor-permission-names">sensor permission name</a>
+     <li><a href="https://w3c.github.io/sensors/#sensor-reading">sensor readings</a>
+     <li><a href="https://w3c.github.io/sensors/#sensor-type">sensor type</a>
+     <li><a href="https://w3c.github.io/sensors/#supported-sensor-options">supported sensor options</a>
+     <li><a href="https://w3c.github.io/sensors/#user-identifying">user identifying</a>
     </ul>
    <li>
     <a data-link-type="biblio">[INFRA]</a> defines the following terms:
@@ -1835,8 +1836,8 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
    <li>
     <a data-link-type="biblio">[screen-orientation]</a> defines the following terms:
     <ul>
-     <li><a href="https://w3c.github.io/screen-orientation#dfn-current-orientation-type">current orientation type</a>
-     <li><a href="https://w3c.github.io/screen-orientation#dom-screen">dom screen</a>
+     <li><a href="https://www.w3.org/TR/screen-orientation/#dfn-current-orientation-type">current orientation type</a>
+     <li><a href="https://www.w3.org/TR/screen-orientation/#dom-screen">dom screen</a>
     </ul>
    <li>
     <a data-link-type="biblio">[WEBIDL]</a> defines the following terms:


### PR DESCRIPTION
- Use TR version for [SCREEN-ORIENTATION]
- Fix broken fragments:
  https://w3c.github.io/screen-orientation#dfn-current-orientation-type
  https://w3c.github.io/screen-orientation#dom-screen
  https://w3c.github.io/sensors#sensor-readings
- Avoid redundant redirects:
  https://w3c.github.io/sensors -> https://w3c.github.io/sensors/