### PR TITLE
Amend PNG image fallback code

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -203,7 +203,7 @@ provide 0 (m/s<sup>2</sup>) [=acceleration=] value for each axis.
 The sign of the [=acceleration=] values must be according to the right-hand convention in a [=local coordinate
 system=] (see figure below).
 
-<img src="images/accelerometer_coordinate_system.svg" onerror="this.src='images/accelerometer_coordinate_system.png'" style="display: block;margin: auto;" alt="Accelerometer coordinate system.">
+<img src="images/accelerometer_coordinate_system.svg" onerror="if (/\.svg$/.test(this.src)) this.src='images/accelerometer_coordinate_system.png'" style="display: block;margin: auto;" alt="Accelerometer coordinate system.">
 
 The {{LinearAccelerationSensor}} class is an {{Accelerometer}}'s subclass. The {{LinearAccelerationSensor}}'s
 [=latest reading=] contains device's [=linear acceleration=] about the corresponding axes.


### PR DESCRIPTION
The "onerror" handler for the SVG image that aims at replacing the image with a PNG version created an infinite loop in the (unlikely, granted) event when there are transient network troubles (due to the server or the connection) after the spec has been retrieved but before the SVG image has been retrieved.

In such a scenario, the fetch on the image would trigger the handler, which would change the image source to the URL of the PNG image, which would trigger another fetch, which would trigger the handler, which would change the source to the same value but that's enough to trigger another fetch, etc.

This fix only changes the source URL once.

Actually, the scenario that more directly affects me is that of a crawling tool that wants to render the spec in a headless browser while avoiding unnecessary network requests (typically those on images): the headless browser would keep on issuing network requests, and fail to report that the spec seems "done loading".

The same problem exists on the Magnetometer spec. If that solution works here, I'll create the same pull request there...


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/accelerometer/pull/55.html" title="Last updated on Feb 28, 2020, 1:03 PM UTC (d4b4ad8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/accelerometer/55/14efbdd...tidoust:d4b4ad8.html" title="Last updated on Feb 28, 2020, 1:03 PM UTC (d4b4ad8)">Diff</a>