### PR TITLE
Make default allowlist normative

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -188,7 +188,9 @@ The <dfn id="accelerometer-sensor-type">Accelerometer</dfn> <a>sensor type</a>'s
 
 The <a>Accelerometer</a> has a [=default sensor=], which is the device's main accelerometer sensor.
 
-The <a>Accelerometer</a> has an associated [=sensor permission name=] which is <a for="PermissionName" enum-value>"accelerometer"</a>.
+The <a>Accelerometer</a> has an associated [=sensor permission name=], which is <a for="PermissionName" enum-value>"accelerometer"</a>.
+
+The <a>Accelerometer</a> is a [=policy-controlled feature=] identified by the string "accelerometer". Its [=default allowlist=] is `'self'`.
 
 A [=latest reading=] for a {{Sensor}} of <a>Accelerometer</a> <a>sensor type</a> includes three [=map/entries=]
 whose [=map/keys=] are "x", "y", "z" and whose [=map/values=] contain device's [=acceleration=]


### PR DESCRIPTION
Fix #60

See also https://www.w3.org/2021/04/08-dap-minutes.html#r01

After some thought, I felt it is clearer to define this in each concrete sensor spec, rather that use inheritance. If this looks good, I'll replicate this to the other concrete sensor specs.

I felt this one-liner fits into the existing section, instead of a new "Permissions Policy Integration" section.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/accelerometer/pull/61.html" title="Last updated on Aug 27, 2021, 10:27 AM UTC (4a849bd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/accelerometer/61/f3acddc...4a849bd.html" title="Last updated on Aug 27, 2021, 10:27 AM UTC (4a849bd)">Diff</a>