### PR TITLE
Update stability status in SOTD

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -23,6 +23,7 @@ Boilerplate: omit issues-index, omit conformance, repository-issue-tracking no
 Include MDN Panels: if possible
 Implementation Report: https://www.w3.org/wiki/DAS/Implementations
 Default Biblio Status: current
+Status Text: This document is maintained and updated at any time. Some parts of this document are work in progress.
 Note class: note
 </pre>
 <pre class="anchors">


### PR DESCRIPTION
Required to pass specberus sotd.draft-stability test and to unblock TR publication.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/accelerometer/pull/63.html" title="Last updated on Dec 3, 2021, 11:21 AM UTC (0e5f3ec)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/accelerometer/63/624a51f...0e5f3ec.html" title="Last updated on Dec 3, 2021, 11:21 AM UTC (0e5f3ec)">Diff</a>