### PR TITLE
Clean up Bikeshed metadata.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -13,18 +13,15 @@ Abstract:
   obtaining information about [=acceleration=] applied to the X, Y and Z axis
   of a device that hosts the sensor.
 Version History: https://github.com/w3c/accelerometer/commits/main/index.bs
-Issue Tracking: Accelerometer Issues Repository https://github.com/w3c/accelerometer/issues
 Indent: 2
 Repository: w3c/accelerometer
 Markup Shorthands: markdown on
 Inline Github Issues: true
-!Test Suite: <a href="https://github.com/web-platform-tests/wpt/tree/main/accelerometer">web-platform-tests on GitHub</a>
-Boilerplate: omit issues-index, omit conformance, repository-issue-tracking no
+Test Suite: https://github.com/web-platform-tests/wpt/tree/main/accelerometer
 Include MDN Panels: if possible
 Implementation Report: https://www.w3.org/wiki/DAS/Implementations
 Default Biblio Status: current
 Status Text: This document is maintained and updated at any time. Some parts of this document are work in progress.
-Note class: note
 </pre>
 <pre class="anchors">
 urlPrefix: https://w3c.github.io/sensors/; spec: GENERIC-SENSOR
@@ -449,23 +446,3 @@ Acknowledgements {#acknowledgements}
 ================
 
 Tobie Langel for the work on Generic Sensor API.
-
-Conformance {#conformance}
-===========
-
-Conformance requirements are expressed with a combination of
-descriptive assertions and RFC 2119 terminology. The key words "MUST",
-"MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT",
-"RECOMMENDED", "MAY", and "OPTIONAL" in the normative parts of this
-document are to be interpreted as described in RFC 2119.
-However, for readability, these words do not appear in all uppercase
-letters in this specification.
-
-All of the text of this specification is normative except sections
-explicitly marked as non-normative, examples, and notes. [[!RFC2119]]
-
-A <dfn>conformant user agent</dfn> must implement all the requirements
-listed in this specification that are applicable to user agents.
-
-The IDL fragments in this specification must be interpreted as required for
-conforming IDL fragments, as described in the Web IDL specification. [[!WEBIDL]]


### PR DESCRIPTION
- Remove "Issue Tracking" key and "repository-issue-tracking no" from
  Boilerplate to let Bikeshed automatically add a link to the GitHub issues
  URL under "Feedback".
- "Test Suite" is a valid key in Bikeshed, so there is no need to declare it
  as custom. Follow Bikeshed's documentation and provide a URL rather than a
  `<a>` block.
- Remove custom Conformance section, let Bikeshed generate it from
  `dap`'s boilerplate in Bikeshed's spec-data.
- Remove "Note class" key, it is set to Bikeshed's default value.
- There is no need to explicitly tell Bikeshed not to include an issues
  index, as Bikeshed does not add it due to the lack of an "issues" class in
  CSS.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/accelerometer/pull/65.html" title="Last updated on Dec 8, 2021, 2:24 PM UTC (8ff7cce)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/accelerometer/65/9daa09d...rakuco:8ff7cce.html" title="Last updated on Dec 8, 2021, 2:24 PM UTC (8ff7cce)">Diff</a>