### PR TITLE
Define and export "accelerometer" permission

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -187,7 +187,7 @@ The <dfn id="accelerometer-sensor-type">Accelerometer</dfn> <a>sensor type</a>'s
 The <a>Accelerometer</a> has a [=default sensor=], which is the device's main accelerometer sensor.
 
 The <a>Accelerometer</a> is a [=powerful feature=] that is identified by the
-[=powerful feature/name=] "accelerometer", which is also its associated
+[=powerful feature/name=] "<dfn permission export>accelerometer</dfn>", which is also its associated
 [=sensor permission name=]. Its [=powerful feature/permission revocation algorithm=] is the
 result of calling the [=generic sensor permission revocation algorithm=] with
 "accelerometer".
@@ -199,7 +199,7 @@ whose [=map/keys=] are "x", "y", "z" and whose [=map/values=] contain device's [
 about the corresponding axes. Values can contain also device's [=linear acceleration=] or [=gravity=]
 depending on which object was instantiated.
 
-The <dfn>acceleration</dfn> is the rate of change of velocity of a device with respect to time. Its 
+The <dfn>acceleration</dfn> is the rate of change of velocity of a device with respect to time. Its
 unit is the metre per second squared (m/s<sup>2</sup>) [[SI]].
 
 The frame of reference for the [=acceleration=] measurement must be inertial, such as, the device in free fall would


### PR DESCRIPTION
This way we can eventually link to it from https://w3c.github.io/permissions-registry/


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/miketaylr/accelerometer/pull/67.html" title="Last updated on Oct 18, 2022, 12:49 AM UTC (9f8936a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/accelerometer/67/957528a...miketaylr:9f8936a.html" title="Last updated on Oct 18, 2022, 12:49 AM UTC (9f8936a)">Diff</a>