### PR TITLE
editorial: Remove "sensor reading" custom anchor.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -33,7 +33,6 @@ urlPrefix: https://w3c.github.io/sensors/; spec: GENERIC-SENSOR
     text: initialize a sensor object; url: initialize-a-sensor-object
     text: sensor type
     text: local coordinate system
-    text: sensor readings; url: sensor-reading
     text: check sensor policy-controlled features; url: check-sensor-policy-controlled-features
     text: location tracking; url: location-tracking
     text: keylogging; url: keystroke-monitoring


### PR DESCRIPTION
w3c/sensors#456 started exporting the definition, so there is no need to
have a custom anchor anymore.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/accelerometer/pull/68.html" title="Last updated on Jan 30, 2023, 10:27 AM UTC (926b864)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/accelerometer/68/34cfefb...rakuco:926b864.html" title="Last updated on Jan 30, 2023, 10:27 AM UTC (926b864)">Diff</a>