### PR TITLE
Rewrite Automation section after changes in Generic Sensor API spec

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -38,9 +38,6 @@ urlPrefix: https://w3c.github.io/sensors/; spec: GENERIC-SENSOR
     text: user identifying; url: user-identifying
     text: generic mitigations; url: mitigation-strategies
     text: supported sensor options
-    text: automation
-    text: mock sensor type
-    text: mock sensor reading values
 urlPrefix: https://www.w3.org/TR/screen-orientation/; spec: SCREEN-ORIENTATION
   type: dfn
     text: current orientation type;  url: dfn-current-orientation-type
@@ -428,42 +425,35 @@ Abstract Operations {#abstract-opertaions}
 
 Automation {#automation}
 ==========
-This section extends the [=automation=] section defined in the Generic Sensor API [[GENERIC-SENSOR]]
-to provide mocking information about the [=acceleration=] applied to the X, Y and Z axis of a device
-that hosts the sensor for the purposes of testing a user agent's implementation of {{Accelerometer}},
-{{LinearAccelerationSensor}} and {{GravitySensor}} APIs.
 
-<h3 id="mock-accelerometer-type">Mock Sensor Type</h3>
+This section extends [[GENERIC-SENSOR#automation]] by providing [=Accelerometer=]-specific virtual sensor metadata.
 
-The {{Accelerometer}} class has an associated [=mock sensor type=] which is
-<a for="MockSensorType" enum-value>"accelerometer"</a>, its [=mock sensor reading values=]
-dictionary is defined as follows:
+Accelerometer automation {#accelerometer-automation}
+-----------------------
 
-<pre class="idl">
-  dictionary AccelerometerReadingValues {
-    required double? x;
-    required double? y;
-    required double? z;
-  };
-</pre>
+The [=per-type virtual sensor metadata=] [=map=] must have the following [=map/entry=]:
+: [=map/key=]
+:: "`accelerometer`"
+: [=map/value=]
+:: A [=virtual sensor metadata=] whose [=virtual sensor metadata/virtual sensor type=] is [=Accelerometer=] and [=reading parsing algorithm=] is [=parse xyz reading=].
 
-The {{LinearAccelerationSensor}} class has an associated [=mock sensor type=] which is
-<a for="MockSensorType" enum-value>"linear-acceleration"</a>, its [=mock sensor reading values=]
-dictionary is defined as follows:
+Linear Accelerometer automation {#linear-accelerometer-automation}
+-----------------------
 
-<pre class="idl">
-  dictionary LinearAccelerationReadingValues : AccelerometerReadingValues {
-  };
-</pre>
+The [=per-type virtual sensor metadata=] [=map=] must have the following [=map/entry=]:
+: [=map/key=]
+:: "`linear-acceleration`"
+: [=map/value=]
+:: A [=virtual sensor metadata=] whose [=virtual sensor metadata/virtual sensor type=] is [=Linear Acceleration Sensor=] and [=reading parsing algorithm=] is [=parse xyz reading=].
 
-The {{GravitySensor}} class has an associated [=mock sensor type=] which is
-<a for="MockSensorType" enum-value>"gravity"</a>, its [=mock sensor reading values=]
-dictionary is defined as follows:
+Gravity automation {#gravity-automation}
+-----------------------
 
-<pre class="idl">
-  dictionary GravityReadingValues : AccelerometerReadingValues {
-  };
-</pre>
+The [=per-type virtual sensor metadata=] [=map=] must have the following [=map/entry=]:
+: [=map/key=]
+:: "`gravity`"
+: [=map/value=]
+:: A [=virtual sensor metadata=] whose [=virtual sensor metadata/virtual sensor type=] is [=Gravity Sensor=] and [=reading parsing algorithm=] is [=parse xyz reading=].
 
 Acknowledgements {#acknowledgements}
 ================


### PR DESCRIPTION
The Automation section in the Generic Sensor API specification was rewritten and several terms and concepts have changed.

This commit adapts the Accelerometer spec to the changes:

- Remove references to "mock sensor type", "mock sensor reading values" and the "MockSensorType" enum.
-  Define an entry in the per-type virtual sensor metadata map whose key is what used to be the "accelerometer", "linear-acceleration" or "gravity" entry in MockSensorType and an appropriate virtual sensor metadata entry.

This is enough to integrate properly with the Generic Sensor spec and allow Accelerometer, Linear Acceleration or Gravity virtual sensors to be created and used.

Fixes #72.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/JuhaVainio/accelerometer/pull/73.html" title="Last updated on Nov 2, 2023, 11:39 AM UTC (99ba593)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/accelerometer/73/a35f6d1...JuhaVainio:99ba593.html" title="Last updated on Nov 2, 2023, 11:39 AM UTC (99ba593)">Diff</a>