### PR TITLE
Adapt to virtual sensor changes in w3c/sensors#475

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -189,6 +189,8 @@ The <dfn id="accelerometer-sensor-type">Accelerometer</dfn> <a>sensor type</a> h
  :: Invoke the [=generic sensor permission revocation algorithm=] with "<code><a permission>accelerometer</a></code>".
  : [=Default sensor=]
  :: The device's main accelerometer sensor.
+ : [=Virtual sensor type=]
+ :: "<code><dfn data-lt="accelerometer virtual sensor type">accelerometer</dfn></code>"
 
 A [=latest reading=] for a {{Sensor}} of <a>Accelerometer</a> <a>sensor type</a> includes three [=map/entries=]
 whose [=map/keys=] are "x", "y", "z" and whose [=map/values=] contain device's [=acceleration=]
@@ -218,6 +220,8 @@ The <dfn id="linear-acceleration-sensor-sensor-type">Linear Acceleration Sensor<
  :: "[=accelerometer-feature|accelerometer=]"
  : [=powerful feature/Permission revocation algorithm=]
  :: Invoke the [=generic sensor permission revocation algorithm=] with "<code><a permission>accelerometer</a></code>".
+ : [=Virtual sensor type=]
+ :: "<code><dfn data-lt="linear-acceleration virtual sensor type">linear-acceleration</dfn></code>"
 
 A [=latest reading=] for a {{Sensor}} of <a>Linear Acceleration Sensor</a> <a>sensor type</a> includes three [=map/entries=]
 whose [=map/keys=] are "x", "y", "z" and whose [=map/values=] contain device's [=linear acceleration=]
@@ -241,6 +245,8 @@ The <dfn id="gravity-sensor-sensor-type">Gravity Sensor</dfn> <a>sensor type</a>
  :: "[=accelerometer-feature|accelerometer=]"
  : [=powerful feature/Permission revocation algorithm=]
  :: Invoke the [=generic sensor permission revocation algorithm=] with "<code><a permission>accelerometer</a></code>".
+ : [=Virtual sensor type=]
+ :: "<code><dfn data-lt="gravity virtual sensor type">gravity</dfn></code>"
 
 A [=latest reading=] for a {{Sensor}} of <a>Gravity Sensor</a> <a>sensor type</a> includes three [=map/entries=]
 whose [=map/keys=] are "x", "y", "z" and whose [=map/values=] contain the acceleration due to [=gravity=]
@@ -433,27 +439,27 @@ Accelerometer automation {#accelerometer-automation}
 
 The [=per-type virtual sensor metadata=] [=map=] must have the following [=map/entry=]:
 : [=map/key=]
-:: "`accelerometer`"
+:: "<code>[=accelerometer virtual sensor type|accelerometer=]</code>"
 : [=map/value=]
-:: A [=virtual sensor metadata=] whose [=virtual sensor metadata/virtual sensor type=] is [=Accelerometer=] and [=reading parsing algorithm=] is [=parse xyz reading=].
+:: A [=virtual sensor metadata=] whose [=virtual sensor metadata/reading parsing algorithm=] is [=parse xyz reading=].
 
 Linear Accelerometer automation {#linear-accelerometer-automation}
 -----------------------
 
 The [=per-type virtual sensor metadata=] [=map=] must have the following [=map/entry=]:
 : [=map/key=]
-:: "`linear-acceleration`"
+:: "<code>[=linear-acceleration virtual sensor type|linear-acceleration=]</code>"
 : [=map/value=]
-:: A [=virtual sensor metadata=] whose [=virtual sensor metadata/virtual sensor type=] is [=Linear Acceleration Sensor=] and [=reading parsing algorithm=] is [=parse xyz reading=].
+:: A [=virtual sensor metadata=] whose [=virtual sensor metadata/reading parsing algorithm=] is [=parse xyz reading=].
 
 Gravity automation {#gravity-automation}
 -----------------------
 
 The [=per-type virtual sensor metadata=] [=map=] must have the following [=map/entry=]:
 : [=map/key=]
-:: "`gravity`"
+:: "<code>[=gravity virtual sensor type|gravity=]</code>"
 : [=map/value=]
-:: A [=virtual sensor metadata=] whose [=virtual sensor metadata/virtual sensor type=] is [=Gravity Sensor=] and [=reading parsing algorithm=] is [=parse xyz reading=].
+:: A [=virtual sensor metadata=] whose [=virtual sensor metadata/reading parsing algorithm=] is [=parse xyz reading=].
 
 Acknowledgements {#acknowledgements}
 ================


### PR DESCRIPTION
The PR above removed the "virtual sensor type" item from the "virtual sensor
metadata" struct and turned it into a string that is referenced from the
automation bits as well as (optionally) defined by a sensor type.

Adapt to it here by removing mentions of `[=virtual sensor metadata/virtual
sensor type=]` from the spec and adding virtual sensor types to each sensor
type defined here.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/accelerometer/pull/74.html" title="Last updated on Nov 28, 2023, 11:04 AM UTC (941d6f3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/accelerometer/74/7cc9b19...rakuco:941d6f3.html" title="Last updated on Nov 28, 2023, 11:04 AM UTC (941d6f3)">Diff</a>