### PR TITLE
editorial: Use permissions and permissions-policy dfn's from DEVICE-ORIENTATION

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -43,6 +43,10 @@ urlPrefix: https://www.w3.org/TR/screen-orientation/; spec: SCREEN-ORIENTATION
     text: current orientation type;  url: dfn-current-orientation-type
     text: dom screen; url: dom-screen
 </pre>
+<pre class=link-defaults>
+spec:orientation-event; type:dfn; text:accelerometer-feature
+spec:orientation-event; type:permission; text:accelerometer
+</pre>
 
 <pre class=biblio>
 {
@@ -169,7 +173,7 @@ in the Generic Sensor API [[!GENERIC-SENSOR]].
 Permissions Policy integration {#permissions-policy-integration}
 ==============================
 
-This specification defines a [=policy-controlled feature=] identified by the string "<code><dfn data-lt="accelerometer-feature" export>accelerometer</dfn></code>". Its [=default allowlist=] is "`self`".
+This specification utilizes the [=policy-controlled feature=] identified by the string "<code><a data-lt="accelerometer-feature">accelerometer</a></code>" defined in [[DEVICE-ORIENTATION#permissions-policy-integration]].
 
 Model {#model}
 =====
@@ -182,7 +186,7 @@ The <dfn id="accelerometer-sensor-type">Accelerometer</dfn> <a>sensor type</a> h
  : [=Extension sensor interface=]
  :: {{Accelerometer}}
  : [=Sensor permission names=]
- :: "<code><dfn permission export>accelerometer</dfn></code>"
+ :: "<code><a permission>accelerometer</a></code>"
  : [=Sensor feature names=]
  :: "[=accelerometer-feature|accelerometer=]"
  : [=powerful feature/Permission revocation algorithm=]


### PR DESCRIPTION
Adapt to w3c/deviceorientation#121 and w3c/deviceorientation#123.

Those two PRs have moved the definition of the "accelerometer"
permission name and permissions policy token to the Device Orientation
spec, which is more widely implemented than this specification and can
be referenced from this one.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/accelerometer/pull/75.html" title="Last updated on Jan 4, 2024, 3:27 PM UTC (f5b2ad5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/accelerometer/75/7fd366f...rakuco:f5b2ad5.html" title="Last updated on Jan 4, 2024, 3:27 PM UTC (f5b2ad5)">Diff</a>