### PR TITLE
editorial: Use some virtual sensor type dfns from DEVICE-ORIENTATION

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -194,7 +194,7 @@ The <dfn id="accelerometer-sensor-type">Accelerometer</dfn> <a>sensor type</a> h
  : [=Default sensor=]
  :: The device's main accelerometer sensor.
  : [=Virtual sensor type=]
- :: "<code><dfn data-lt="accelerometer virtual sensor type">accelerometer</dfn></code>"
+ :: "<code><a data-lt="accelerometer virtual sensor type">accelerometer</a></code>"
 
 A [=latest reading=] for a {{Sensor}} of <a>Accelerometer</a> <a>sensor type</a> includes three [=map/entries=]
 whose [=map/keys=] are "x", "y", "z" and whose [=map/values=] contain device's [=acceleration=]
@@ -225,7 +225,7 @@ The <dfn id="linear-acceleration-sensor-sensor-type">Linear Acceleration Sensor<
  : [=powerful feature/Permission revocation algorithm=]
  :: Invoke the [=generic sensor permission revocation algorithm=] with "<code><a permission>accelerometer</a></code>".
  : [=Virtual sensor type=]
- :: "<code><dfn data-lt="linear-acceleration virtual sensor type">linear-acceleration</dfn></code>"
+ :: "<code><a data-lt="linear-acceleration virtual sensor type">linear-acceleration</a></code>"
 
 A [=latest reading=] for a {{Sensor}} of <a>Linear Acceleration Sensor</a> <a>sensor type</a> includes three [=map/entries=]
 whose [=map/keys=] are "x", "y", "z" and whose [=map/values=] contain device's [=linear acceleration=]
@@ -436,25 +436,17 @@ Abstract Operations {#abstract-opertaions}
 Automation {#automation}
 ==========
 
-This section extends [[GENERIC-SENSOR#automation]] by providing [=Accelerometer=]-specific virtual sensor metadata.
+This section extends [[GENERIC-SENSOR#automation]] by providing [=Accelerometer=]-specific virtual sensor metadata. Some of the [=virtual sensor types=] used by this specification are defined in [[DEVICE-ORIENTATION]].
 
 Accelerometer automation {#accelerometer-automation}
 -----------------------
 
-The [=per-type virtual sensor metadata=] [=map=] must have the following [=map/entry=]:
-: [=map/key=]
-:: "<code>[=accelerometer virtual sensor type|accelerometer=]</code>"
-: [=map/value=]
-:: A [=virtual sensor metadata=] whose [=virtual sensor metadata/reading parsing algorithm=] is [=parse xyz reading=].
+The [=accelerometer virtual sensor type=] and its corresponding entry in the [=per-type virtual sensor metadata=] [=map=] are defined in [[DEVICE-ORIENTATION#automation]].
 
 Linear Accelerometer automation {#linear-accelerometer-automation}
 -----------------------
 
-The [=per-type virtual sensor metadata=] [=map=] must have the following [=map/entry=]:
-: [=map/key=]
-:: "<code>[=linear-acceleration virtual sensor type|linear-acceleration=]</code>"
-: [=map/value=]
-:: A [=virtual sensor metadata=] whose [=virtual sensor metadata/reading parsing algorithm=] is [=parse xyz reading=].
+The [=linear-acceleration virtual sensor type=] and its corresponding entry in the [=per-type virtual sensor metadata=] [=map=] are defined in [[DEVICE-ORIENTATION#automation]].
 
 Gravity automation {#gravity-automation}
 -----------------------


### PR DESCRIPTION
Adapt to w3c/deviceorientation#124, which added and exported `dfn`s
for "accelerometer virtual sensor type" and "linear-acceleration
virtual sensor type" to be shared by that specification and this one.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/accelerometer/pull/77.html" title="Last updated on Jan 8, 2024, 8:49 AM UTC (0afbaa0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/accelerometer/77/fcc8879...0afbaa0.html" title="Last updated on Jan 8, 2024, 8:49 AM UTC (0afbaa0)">Diff</a>