### PR TITLE
Amend PNG image fallback code

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -277,7 +277,7 @@ the display and Z-axis is the vector product of X and Y axes and it points outwa
 the display, and towards the viewer. The [=device coordinate system=] remains stationary
 regardless of the [=dom screen=] orientation (see figure below).
 
-<img src="images/device_coordinate_system.svg" onerror="this.src='images/device_coordinate_system.png'" style="display: block;margin: auto;" alt="Device coordinate system.">
+<img src="images/device_coordinate_system.svg" onerror="if (/\.svg$/.test(this.src)) this.src='images/device_coordinate_system.png'" style="display: block;margin: auto;" alt="Device coordinate system.">
 
 The <dfn export>screen coordinate system</dfn> is defined as a three dimensional
 Cartesian coordinate system (x, y, z), which is bound to the [=dom screen=].
@@ -287,7 +287,7 @@ the X-axis points towards the right of the [=dom screen=] and Z-axis is the
 vector product of X and Y axes and it and it points outwards from the [=dom screen=],
 and towards the viewer (see figure below).
 
-<img src="images/screen_coordinate_system.svg" onerror="this.src='images/screen_coordinate_system.png'" style="display: block;margin: auto;" alt="Screen coordinate system.">
+<img src="images/screen_coordinate_system.svg" onerror="if (/\.svg$/.test(this.src)) this.src='images/screen_coordinate_system.png'" style="display: block;margin: auto;" alt="Screen coordinate system.">
 
 The main difference between the [=device coordinate system=] and the [=screen coordinate system=],
 is that the [=screen coordinate system=] always follows the [=dom screen=] orientation,


### PR DESCRIPTION
Same initial problem as in #55 for SVG images that were introduced more recently: the PNG fallback mechanism can lead to an infinite loading loop when neither the SVG nor the PNG image can be retrieved (due to transient network errors, or in crawlers that choose to avoid loading images).

Same problem, same fix :)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/accelerometer/pull/78.html" title="Last updated on Jun 7, 2024, 7:58 AM UTC (9335137)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/accelerometer/78/52bdfcb...tidoust:9335137.html" title="Last updated on Jun 7, 2024, 7:58 AM UTC (9335137)">Diff</a>