### PR TITLE
Fix "accelerometer" feature name references

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -43,10 +43,6 @@ urlPrefix: https://www.w3.org/TR/screen-orientation/; spec: SCREEN-ORIENTATION
     text: current orientation type;  url: dfn-current-orientation-type
     text: dom screen; url: dom-screen
 </pre>
-<pre class=link-defaults>
-spec:orientation-event; type:dfn; text:accelerometer-feature
-spec:orientation-event; type:permission; text:accelerometer
-</pre>
 
 <pre class=biblio>
 {
@@ -173,7 +169,7 @@ in the Generic Sensor API [[!GENERIC-SENSOR]].
 Permissions Policy integration {#permissions-policy-integration}
 ==============================
 
-This specification utilizes the [=policy-controlled feature=] identified by the string "<code><a data-lt="accelerometer-feature">accelerometer</a></code>" defined in [[DEVICE-ORIENTATION#permissions-policy-integration]].
+This specification utilizes the [=policy-controlled feature=] identified by the string <code><a permission>"accelerometer"</a></code> defined in [[DEVICE-ORIENTATION#permissions-integration]].
 
 Model {#model}
 =====
@@ -188,7 +184,7 @@ The <dfn id="accelerometer-sensor-type">Accelerometer</dfn> <a>sensor type</a> h
  : [=Sensor permission names=]
  :: "<code><a permission>accelerometer</a></code>"
  : [=Sensor feature names=]
- :: "[=accelerometer-feature|accelerometer=]"
+ :: <a permission>"accelerometer"</a>
  : [=powerful feature/Permission revocation algorithm=]
  :: Invoke the [=generic sensor permission revocation algorithm=] with "<code><a permission>accelerometer</a></code>".
  : [=Default sensor=]
@@ -221,7 +217,7 @@ The <dfn id="linear-acceleration-sensor-sensor-type">Linear Acceleration Sensor<
  : [=Sensor permission names=]
  :: "<code><a permission>accelerometer</a></code>"
  : [=Sensor feature names=]
- :: "[=accelerometer-feature|accelerometer=]"
+ :: <a permission>"accelerometer"</a>
  : [=powerful feature/Permission revocation algorithm=]
  :: Invoke the [=generic sensor permission revocation algorithm=] with "<code><a permission>accelerometer</a></code>".
  : [=Virtual sensor type=]
@@ -246,7 +242,7 @@ The <dfn id="gravity-sensor-sensor-type">Gravity Sensor</dfn> <a>sensor type</a>
  : [=Sensor permission names=]
  :: "<code><a permission>accelerometer</a></code>"
  : [=Sensor feature names=]
- :: "[=accelerometer-feature|accelerometer=]"
+ :: <a permission>"accelerometer"</a>
  : [=powerful feature/Permission revocation algorithm=]
  :: Invoke the [=generic sensor permission revocation algorithm=] with "<code><a permission>accelerometer</a></code>".
  : [=Virtual sensor type=]


### PR DESCRIPTION
The permission names are shared across Permissions and Permissions Policy specs: https://www.w3.org/TR/permissions/#relationship-to-permissions-policy

Removes the need for Bikeshed’s manually-maintained list of special linking rules, can use the definition type-based namespacing syntax for both instead: <dfn permission export>"accelerometer"</dfn> -> <a permission>"accelerometer"</a> https://speced.github.io/bikeshed/#dfn-types


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/accelerometer/pull/81.html" title="Last updated on Oct 7, 2024, 1:19 PM UTC (75e7eaf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/accelerometer/81/b7da34f...75e7eaf.html" title="Last updated on Oct 7, 2024, 1:19 PM UTC (75e7eaf)">Diff</a>