### PR TITLE
Add SotD implementation status advisement

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -21,7 +21,15 @@ Test Suite: https://github.com/web-platform-tests/wpt/tree/main/accelerometer
 Include MDN Panels: if possible
 Implementation Report: https://www.w3.org/wiki/DAS/Implementations
 Default Biblio Status: current
-Status Text: This document is maintained and updated at any time. Some parts of this document are work in progress.
+Status Text: <div class="advisement">
+  This specification is currently implemented in a single browser engine (Blink).
+  The <a href="https://www.w3.org/TR/device-orientation/">Device Orientation and Motion</a>
+  specification provides equivalent functionality and is implemented across major browser engines.
+  This specification is being maintained to support existing deployed content.
+  Implementer standards positions:
+  <a href="https://github.com/WebKit/standards-positions/issues/347">WebKit</a>,
+  <a href="https://github.com/mozilla/standards-positions/issues/35">Mozilla</a>.
+  </div>
 </pre>
 <pre class="anchors">
 urlPrefix: https://w3c.github.io/sensors/; spec: GENERIC-SENSOR

--- a/index.bs
+++ b/index.bs
@@ -23,9 +23,8 @@ Implementation Report: https://www.w3.org/wiki/DAS/Implementations
 Default Biblio Status: current
 Status Text: <div class="advisement">
   This specification is currently implemented in a single browser engine (Blink).
-  The <a href="https://www.w3.org/TR/device-orientation/">Device Orientation and Motion</a>
-  specification provides equivalent functionality and is implemented across major browser engines.
-  This specification is being maintained to support existing deployed content.
+  The [[DEVICE-ORIENTATION]] specification provides equivalent functionality and is implemented across major browser engines.
+  This specification is being maintained while websites migrate to [[DEVICE-ORIENTATION]].
   Implementer standards positions:
   <a href="https://github.com/WebKit/standards-positions/issues/347">WebKit</a>,
   <a href="https://github.com/mozilla/standards-positions/issues/35">Mozilla</a>.


### PR DESCRIPTION
Adds a `.advisement` box to the Status of This Document section to signal implementation status to developers at a glance.

Per TAG requirement ([w3ctag/design-reviews#1187](https://github.com/w3ctag/design-reviews/issues/1187#issuecomment-3889788860)):

> At a minimum, each document's support level should be in its SotD section, but ideally the WG would find a way to ensure that developers reading a specification can tell at a glance which kind of document they're reading.

All implementation status claims are verified against MDN BCD. Standards position URLs are verified against the live issues.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/marcoscaceres/accelerometer/pull/84.html" title="Last updated on Mar 31, 2026, 4:55 AM UTC (328f1da)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/accelerometer/84/8f50f93...marcoscaceres:328f1da.html" title="Last updated on Mar 31, 2026, 4:55 AM UTC (328f1da)">Diff</a>